### PR TITLE
book: add learning objectives and EDA part pointers

### DIFF
--- a/eda_overview.qmd
+++ b/eda_overview.qmd
@@ -39,4 +39,25 @@ EDA will serve as a compass, guiding you towards the true value hidden within
 your data. And with that, you've successfully completed your journey through
 exploratory data analysis.
 
+## What you'll learn in this part
+
+- Get a feel for the **shape** of a dataset — its size, variables, and missing
+  pieces — before drawing any conclusions.
+- **Transform and summarize** tabular data with the `dplyr` verbs (filter, select,
+  mutate, group, summarize).
+- Work through a complete EDA on a real survey dataset, from raw table to
+  summary.
+- **Visualize** distributions and relationships with `ggplot2`, and apply a few
+  design principles that make any plot more readable.
+- Treat EDA as an **iterative loop**: ask a question, make a summary or plot,
+  refine the question, repeat.
+
+## Where to begin
+
+We start gently, with the `dplyr` verbs on a small, friendly dataset in
+[Introduction to dplyr](dplyr_intro_msleep.qmd), then put them to work in a full
+[case study on survey data](eda_and_univariate_brfss.qmd) before turning to
+visualization with [ggplot2](ggplot2/intro.qmd) and a
+[self-guided tour of data visualization](visualization_guide.qmd).
+
 

--- a/intro_to_rstudio.qmd
+++ b/intro_to_rstudio.qmd
@@ -6,7 +6,17 @@ code. RStudio also provides several other useful features, including a
 built-in console, syntax-highlighting editor, and tools for plotting, history,
 debugging, workspace management, and workspace viewing. RStudio is available in
 both free and commercial editions; the commercial edition provides some additional
-features, including support for multiple sessions and enhanced debugging. 
+features, including support for multiple sessions and enhanced debugging.
+
+## What you'll learn
+
+- Install R and RStudio and launch the RStudio IDE.
+- Identify the four panes of the RStudio interface and what each is for.
+- Recognize that only the **console** talks to R directly — the other panes are a
+  convenience layer on top.
+- Customize the layout to suit your screen and preferences.
+- Name the main alternatives to RStudio (Jupyter, VS Code, Positron, plain
+  command-line R) and when you might reach for them.
 
 ## Getting started with RStudio
  

--- a/r_intro_mechanics.qmd
+++ b/r_intro_mechanics.qmd
@@ -6,6 +6,17 @@ knitr::opts_chunk$set(
     cache=as.logical(Sys.getenv("KNITR_CACHE", "TRUE")))
 ```
 
+## What you'll learn
+
+- Start R and interact with it by typing at the console.
+- Tell the two basic kinds of input apart: **assignments** (storing a value) and
+  **expressions** (computing a result).
+- Use R as a calculator, applying its arithmetic operators and order of
+  operations.
+- Assign values to named **objects** with the `<-` operator, and inspect, change,
+  and remove them.
+- Apply R's rules for naming objects.
+- Look up documentation with `help()` and `?`.
 
 ## Starting R
 


### PR DESCRIPTION
Bring the remaining early chapters in line with the rest of the book, which opens each chapter with a 'What you'll learn' section:

- intro_to_rstudio.qmd and r_intro_mechanics.qmd: add 'What you'll learn'.
- eda_overview.qmd: add a 'What you'll learn in this part' list and a 'Where to begin' section pointing to the dplyr, BRFSS case-study, and visualization chapters, so the part opener is no longer a dead end.