### PR TITLE
book: apply cross-reference and resources-appendix edits

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -103,11 +103,9 @@ book:
     - references.qmd
 
   appendices:
-    - appendix.qmd
     - git_and_github.qmd
     - additional_resources.qmd
     - ai_tools.qmd
-    - dataviz.qmd
     - matrix_exercises.qmd
     #- part: "Bioconductor"
     #chapters:

--- a/additional_resources.qmd
+++ b/additional_resources.qmd
@@ -1,12 +1,74 @@
-## Additional resources
+---
+title: "Further reading, cheat sheets, and datasets"
+---
 
-* [Base R Cheat Sheet](https://iqss.github.io/dss-workshops/R/Rintro/base-r-cheat-sheet.pdf)
+No single book can cover everything, and this one does not try to. This appendix
+collects the resources I reach for most often: quick-reference cheat sheets, free
+online books that go deeper than we can here, documentation for the key packages
+used throughout the chapters, and the datasets and interactive tools that support
+the material. Treat it as a launch pad for the self-directed learning the
+[preface](index.qmd) argues for.
+
+## Cheat sheets
+
+Cheat sheets are dense, one- or two-page summaries you keep open beside your code.
+Posit (formerly RStudio) maintains a gallery of polished cheat sheets for the
+tidyverse and the RStudio IDE, and the Bioconductor project publishes one for its
+core classes.
+
+* [Posit cheat sheet gallery](https://posit.co/resources/cheatsheets/) — the hub
+  for all of the sheets below (and the [source repository](https://github.com/rstudio/cheatsheets))
+* [Base R cheat sheet](https://iqss.github.io/dss-workshops/R/Rintro/base-r-cheat-sheet.pdf)
+* [RStudio IDE cheat sheet](https://rstudio.github.io/cheatsheets/rstudio-ide.pdf) — see the [RStudio chapter](intro_to_rstudio.qmd)
+* [Data transformation with `dplyr`](https://rstudio.github.io/cheatsheets/data-transformation.pdf) — see the [dplyr chapter](dplyr_intro_msleep.qmd)
+* [Data visualization with `ggplot2`](https://rstudio.github.io/cheatsheets/data-visualization.pdf) — see the [visualization chapters](visualization_guide.qmd)
+* [Tidy data with `tidyr`](https://rstudio.github.io/cheatsheets/tidyr.pdf)
+* [Reading data with `readr`](https://rstudio.github.io/cheatsheets/data-import.pdf) — see [Reading and writing data](reading_and_writing.qmd)
+* [Factors with `forcats`](https://rstudio.github.io/cheatsheets/factors.pdf) — see the [factors chapter](factors.qmd)
+
+## Free online books
+
+* [R for Data Science (2e)](https://r4ds.hadley.nz/) — the standard tidyverse introduction
+* [Hands-on Programming with R](https://rstudio-education.github.io/hopr/) — gentle, project-driven; the source of several figures in this book
 * [Modern Data Visualization with R](https://rkabacoff.github.io/datavis/)
+* [ggplot2: Elegant Graphics for Data Analysis](https://ggplot2-book.org/) — the definitive `ggplot2` reference
+* [Advanced R](https://adv-r.hadley.nz/) — for when you want to understand *how* R works
+* [Bioconductor: an introduction](https://carpentries-incubator.github.io/bioc-intro/) — Carpentries-style Bioconductor onboarding
+* [Orchestrating Single-Cell Analysis with Bioconductor (OSCA)](https://bioconductor.org/books/release/OSCA/) — companion to the [single-cell chapter](single_cell/setup.qmd)
+* [Computational Genomics with R](https://compgenomr.github.io/book/)
 
-## AI 
+## Package and project documentation
 
-* [chatGPT](https://chat.openai.com/chat)
-* [Gemini](https://gemini.google.com/app)
-* [Claude](https://claude.ai/)
-* [DeepSeek](https://deepseek.com/) 
-* [Perplexity](https://www.perplexity.ai/)
+* [Bioconductor](https://bioconductor.org/) — the project home; every package has a *vignette* worth reading
+* [The tidyverse](https://www.tidyverse.org/) — `dplyr`, `ggplot2`, `tidyr`, and friends
+* [`mlr3` book](https://mlr3book.mlr-org.com/) — the framework used in the [machine learning chapters](machine_learning/intro.qmd)
+* [`ComplexHeatmap` reference](https://jokergoo.github.io/ComplexHeatmap-reference/book/) — production heatmaps beyond `pheatmap`
+* [R Graph Gallery](https://www.r-graph-gallery.com/) and [From Data to Viz](https://data-to-viz.com/) — pick the right chart and copy the code
+
+## Interactive practice: swirl
+
+[swirl](https://swirlstats.com/) teaches you R *inside* R: it runs lessons at the
+console and checks your answers as you go. To get started, install and launch it:
+
+```{r eval=FALSE}
+install.packages("swirl")
+library("swirl")
+swirl()
+```
+
+Then follow the prompts and pick a course.
+
+## Datasets used in this book
+
+* [BRFSS subset](BRFSS-subset.csv) — the Behavioral Risk Factor Surveillance
+  System sample analyzed in the [EDA case study](eda_and_univariate_brfss.qmd)
+
+Most other datasets are pulled directly from packages or public repositories
+(NCBI GEO, ENCODE, Bioconductor data packages) by the chapters that use them, so
+there is nothing to download by hand.
+
+## AI assistants
+
+Large language models are a genuinely useful study partner for R and statistics.
+Rather than list them here, this book devotes a full appendix to using them well —
+see [AI Tools for Enhanced Learning and Productivity](ai_tools.qmd).

--- a/data_structures_overview.qmd
+++ b/data_structures_overview.qmd
@@ -44,10 +44,15 @@ approaches to help you better understand and apply these concepts in your work.
   access, and modify lists, and demonstrate their flexibility in handling
   complex data structures.
 * Data.frames
-  : Finally, we will examine data.frames, a widely-used data structure for
+  : Next, we will examine data.frames, a widely-used data structure for
   organizing and manipulating tabular data. You will learn how to create,
   access, and manipulate data.frames, and understand their advantages over
   other data structures for data analysis tasks.
+* Factors
+  : Finally, we will look at factors, R's way of representing categorical data
+  (such as treatment groups or sample conditions). You will learn how factors
+  store their categories as **levels**, why that matters for statistical
+  modeling and plotting, and how to create and reorder them.
 * Arrays
   : While we will not focus directly on the `array` data type, which are
   multidimensional data structures that extend matrices, they are very similar

--- a/genomic_ranges_tutorial.qmd
+++ b/genomic_ranges_tutorial.qmd
@@ -405,5 +405,5 @@ You can now take a real peak set from file to insight:
   biological signal makes it lumpy.
 
 For overlaps, nearest-feature searches, set operations, and gene models, continue
-to the *Genomic ranges and features* chapter, which treats those operations in
-full.
+to the [Genomic ranges and features](ranges_and_signals.qmd) chapter, which treats
+those operations in full.

--- a/ggplot2/intro.qmd
+++ b/ggplot2/intro.qmd
@@ -318,3 +318,5 @@ Reading the final figure (@fig-ggplot-theming), it appears that:
 * A few very high outliers sit in the obese-smoker group.
 
 These findings are tentative. They rest on a limited sample and involve no statistical testing to assess whether the differences could be due to chance.
+
+For the design principles behind these plots — the data-ink ratio, colorblind-safe palettes — and specialized plot types for genomics such as UpSet plots and heatmaps, see [A self-guided tour of data visualization in R](../visualization_guide.qmd).

--- a/kmeans.qmd
+++ b/kmeans.qmd
@@ -393,5 +393,5 @@ shift, and you did it with k-means. Looking back at the objectives:
   moving in step through the diauxic shift.
 
 That wraps up the statistics part of the book. Clustering is your first taste of
-unsupervised learning; the machine-learning chapters pick up that thread and
-build on it.
+unsupervised learning; the [machine-learning chapters](machine_learning/intro.qmd)
+pick up that thread and build on it.

--- a/machine_learning/intro.qmd
+++ b/machine_learning/intro.qmd
@@ -27,8 +27,9 @@ problems it solves, the workflow you follow, and the single most important pitfa
 (overfitting) to watch for. The chapters that follow put these ideas to work — a
 [tour of supervised algorithms](models.qmd) on a shared dataset, the
 [mlr3verse framework](mlr3verse_intro.qmd) for running them cleanly, and
-[worked biological examples](machine_learning_mlr3.qmd) including the
-tumour-classification and age-from-methylation problems we just sketched.
+worked biological examples — including the
+[tumour-classification](ml_cancer.qmd) and
+[age-from-methylation](ml_methylation_age.qmd) problems we just sketched.
 
 ## What you'll learn
 
@@ -67,7 +68,9 @@ studying these example pairs. Supervised problems split further into two types:
 do not have a known answer to predict. Instead, the algorithm looks for structure
 hidden in the data itself. **Clustering** groups similar samples together; you
 might cluster single cells by their expression profiles to discover cell types
-nobody labelled in advance. **Dimensionality reduction** (like PCA) finds the few
+nobody labelled in advance. The [k-means clustering chapter](../kmeans.qmd) works
+through a complete clustering example on real yeast gene-expression data.
+**Dimensionality reduction** (like PCA) finds the few
 underlying factors that explain most of the variation across thousands of genes.
 These methods are often the first thing you reach for when you want to *explore* a
 new dataset before you commit to a specific prediction.


### PR DESCRIPTION
Completes the previous commit (which captured only the file deletions): fix the broken machine_learning/intro.qmd link, cross-link kmeans.qmd with the ML intro both ways, add ggplot2/intro -> visualization_guide, genomic_ranges_tutorial -> ranges_and_signals, and Factors in the data-structures overview; expand additional_resources.qmd and drop the deleted appendix.qmd/dataviz.qmd from _quarto.yml.