### PR TITLE
Add "About" page with AI-use transparency statement

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -47,6 +47,8 @@ book:
     left:
       - href: index.qmd
         text: Home
+      - href: about.qmd
+        text: About
 
   chapters:
     - index.qmd
@@ -123,6 +125,8 @@ book:
     #- bioconductor_packages.qmd
   page-footer:
     center:
+      - text: "About"
+        href: about.qmd
       - text: "License"
         href: license.qmd
 

--- a/about.qmd
+++ b/about.qmd
@@ -1,0 +1,69 @@
+---
+title: "About this book"
+---
+
+This page is a short, honest account of what *The RBioc Book* is, how it was
+made, and — because it would be strange not to say so in a book that encourages
+you to use AI — how AI was used in writing it.
+
+## What this is
+
+The book is a collection of chapters for learning introductory R, statistics, and
+Bioconductor, aimed at biologists and others coming to data science for the first
+time. It is built with [Quarto](https://quarto.org/), executed with `knitr` (so
+the code you read is the code that actually ran), and published openly to GitHub
+Pages. The source lives at
+[github.com/seandavi/RBiocBook](https://github.com/seandavi/RBiocBook), and the
+text is released under [CC0](license.qmd) — use it freely.
+
+## On the use of AI
+
+I have used AI tools, variably, throughout the production of this book, and I want
+to be transparent about it rather than pretend otherwise.
+
+The use has been *variable* by design — some chapters are long-standing class
+material lightly touched, others were drafted, restructured, or substantially
+edited with AI assistance. Where I have leaned into AI, I have leaned into it for
+three things in particular:
+
+- **Editing.** Tightening prose, smoothing transitions, catching inconsistencies,
+  and bringing chapters written over many years into a single, steadier voice.
+- **Producing content.** Drafting explanations, worked examples, exercises, and
+  figures — always reviewed, corrected, and signed off by a human author.
+- **Supporting the content.** Checking that what a chapter claims is *well
+  supported*, both in its **material** (is the statistics correct? does the code
+  run? is the biology right?) and in its **presentation** — that each chapter
+  reflects established **adult-learning best practices** rather than just dumping
+  information.
+
+That last point deserves a word. This book is built on a deliberate pedagogy
+[@knowles_adult_2005; @author_lifelong_2016]: adults learn best when material is
+problem-centered, builds on what they already know, respects their autonomy, and
+gives them early, concrete wins. AI has been a genuinely useful collaborator for
+holding every chapter to that standard — asking, chapter by chapter, whether the
+motivation is concrete, whether jargon is defined before it is used, and whether
+the exercises actually let a reader check their understanding.
+
+::: {.callout-important}
+## AI assists; humans are responsible
+None of this displaces human judgment, and that is the point. Large language
+models produce fluent text that can *feel* authoritative while being subtly wrong,
+and over-reliance on them can erode the very critical thinking this book is trying
+to build [@doi:10.1038/s41586-024-07146-0; @doi:10.1145/3706598.3713778]. So every
+AI contribution here was reviewed against trusted sources, every code chunk was
+executed, and the responsibility for what the book says rests with its human
+authors. AI helped us get there faster and present it better; it did not get the
+final word.
+:::
+
+If you would like to use these tools in your *own* learning — which I encourage —
+the [AI Tools appendix](ai_tools.qmd) is a practical guide to doing so
+effectively and responsibly, and the [preface](index.qmd) says more about the
+learning philosophy behind the book.
+
+## Citing the book
+
+If you use this material, a citation back to
+[seandavi.github.io/RBiocBook](https://seandavi.github.io/RBiocBook) is
+appreciated. The book is a living document; chapters are added and revised over
+time.


### PR DESCRIPTION
## What

Adds a standalone **About** page (`about.qmd`), linked from the **navbar** and the **page footer** (not in the numbered chapter flow). It serves as the book's colophon and, primarily, its **AI-use transparency statement**.

This implements the placement we discussed: meta-information about the artifact belongs on a discoverable, always-visible "About" surface rather than buried as a back-matter appendix — and it keeps the existing `ai_tools.qmd` appendix (AI as a skill *for the reader*) and the Preface cleanly separate from this *production* disclosure.

## Content

States that AI has been used **variably** across the book, and that where we lean into it, we lean into:
- **editing** (voice, consistency),
- **producing content** (drafts, examples, exercises, figures — human-reviewed), and
- **supporting content** — verifying it is well supported both in **material** (correct stats/code/biology) and in **presentation**, according to **adult-learning best practices**.

A `callout-important` makes the boundary explicit: AI assists, human authors are responsible, everything verified against trusted sources.

## References

All already present in the bibliography (no new network resolution needed):
- Adult-learning pedagogy: `@knowles_adult_2005`, `@author_lifelong_2016`
- Responsible AI use: `@doi:10.1038/s41586-024-07146-0` (Messeri & Crockett), `@doi:10.1145/3706598.3713778` (Gen-AI & critical thinking, CHI 2025)

Cross-links to the [AI Tools appendix](ai_tools.qmd) and the [preface](index.qmd).

## Verification

Renders cleanly to HTML: all four citations resolve in-text and in the reference list (no broken markers), "About" appears in navbar and footer, License link intact. Only `about.qmd` (new) and `_quarto.yml` (navbar + footer entries) change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)