### PR TITLE
Add Sean Davis author block to chapters lacking one

### DIFF
--- a/310_microbiome.qmd
+++ b/310_microbiome.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Analyzing microbiome data"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 The human microbiome is a crowded ecosystem of bacteria, viruses, fungi, and other microorganisms living in and on the human body. These microbes shape human health and disease, influencing everything from digestion and metabolism to immune function and mood. Working out *which* microbes are present, in *what* proportions, and how those proportions shift between healthy and sick people is one of the most active areas in biology today.

--- a/about.qmd
+++ b/about.qmd
@@ -1,5 +1,11 @@
 ---
 title: "About this book"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 This page is a short, honest account of what *The RBioc Book* is, how it was

--- a/additional_resources.qmd
+++ b/additional_resources.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Further reading, cheat sheets, and datasets"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 No single book can cover everything, and this one does not try to. This appendix

--- a/ai_tools.qmd
+++ b/ai_tools.qmd
@@ -1,4 +1,12 @@
-# AI Tools for Enhanced Learning and Productivity in Bioinformatics
+---
+title: "AI Tools for Enhanced Learning and Productivity in Bioinformatics"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
+---
 
 The rise of sophisticated Artificial Intelligence (AI) tools, particularly Large Language Models (LLMs), has drastically altered day-to-day tasks for many. This chapter aims to guide you, as biologists venturing into these computational fields, on how to effectively and responsibly harness these AI tools. The focus will be on using them as powerful assistants to deepen your understanding of statistical concepts, enhance your ability to explore complex biological data with R, and ultimately boost your overall productivity and learning experience. Think of these tools not as a shortcut around learning, but as a versatile companion on your journey.
 

--- a/atac-seq/atac-seq.qmd
+++ b/atac-seq/atac-seq.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Genomic ranges and ATAC-seq"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 bibliography: atac.bib
 link-citations: true
 ---

--- a/bioc-summarizedexperiment.qmd
+++ b/bioc-summarizedexperiment.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Storing experiments with SummarizedExperiment"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 An RNA-seq or microarray experiment hands you several things at once: a matrix of

--- a/biology_primer.qmd
+++ b/biology_primer.qmd
@@ -1,6 +1,11 @@
 ---
 title: "A primer on biological assays"
-author: "Sean Davis"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 Somewhere in this book you will be handed a spreadsheet with 20,000 rows and

--- a/dataframes_intro.qmd
+++ b/dataframes_intro.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Data Frames"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 Almost every dataset you will meet in genomics arrives as a table: genes down the

--- a/eda_and_univariate_brfss.qmd
+++ b/eda_and_univariate_brfss.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Case Study: Behavioral Risk Factor Surveillance System"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 

--- a/genomic_ranges_tutorial.qmd
+++ b/genomic_ranges_tutorial.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Genomic ranges with real ChIP-seq peaks"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 CTCF is one of the most important architectural proteins in the human genome. It

--- a/geoquery.qmd
+++ b/geoquery.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Accessing public omics data with GEOquery"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 Someone has already run the experiment you need. Thousands of expression

--- a/ggplot2/intro.qmd
+++ b/ggplot2/intro.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Exploring data with ggplot2"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 A plot answers questions a table of numbers cannot. Does a cost rise with age? Do two groups behave differently? Are there outliers worth a second look? `ggplot2` is the package most R users reach for to ask those questions, and it does so with a small, consistent vocabulary you can combine to build almost any graphic. In this chapter you'll start from a blank canvas and, one layer at a time, build up a single plot that shows four variables at once.

--- a/git_and_github.qmd
+++ b/git_and_github.qmd
@@ -1,4 +1,12 @@
-# Git and GitHub
+---
+title: "Git and GitHub"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
+---
 
 Git is a version control system that allows you to track changes in your code and collaborate with others. GitHub is a web-based platform that hosts Git repositories, making it easy to share and collaborate on projects. Github is NOT the only place to host Git repositories, but it is the most popular and has a large community of users.
 

--- a/intro.qmd
+++ b/intro.qmd
@@ -1,5 +1,11 @@
 ---
 title: "About R"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 Imagine you've just gotten back a spreadsheet with expression values for 20,000

--- a/intro_to_rstudio.qmd
+++ b/intro_to_rstudio.qmd
@@ -1,4 +1,12 @@
-# RStudio
+---
+title: "RStudio"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
+---
 
 RStudio is an integrated development environment (IDE) for R. It provides a
 graphical user interface (GUI) for R, making it easier to write and execute R

--- a/kmeans.qmd
+++ b/kmeans.qmd
@@ -1,5 +1,11 @@
 ---
 title: "K-means clustering"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 When yeast cells run low on glucose, they flip their entire metabolic program —

--- a/lists.qmd
+++ b/lists.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Lists: a catch-all container"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 So far in our journey through R's data structures, we've dealt with vectors and matrices. These are fantastic tools, but they have one strict rule: all their elements must be of the *same data type*. You can have a vector of numbers or a matrix of characters, but you can't mix and match.

--- a/machine_learning/intro.qmd
+++ b/machine_learning/intro.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Introduction to machine learning"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 Suppose you have gene-expression profiles from a hundred tumour biopsies and a

--- a/machine_learning/ml_cancer.qmd
+++ b/machine_learning/ml_cancer.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Worked example: classifying cancer types from gene expression"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 The earlier machine learning chapters introduced the *ideas*: the difference

--- a/machine_learning/ml_expression.qmd
+++ b/machine_learning/ml_expression.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Worked example: predicting gene expression from histone marks"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 A gene's DNA sequence doesn't change from one cell type to the next, yet the same

--- a/machine_learning/ml_methylation_age.qmd
+++ b/machine_learning/ml_methylation_age.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Worked example: predicting age from DNA methylation"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 How old is a tissue sample? Not the donor's age on a birthday cake, but the

--- a/machine_learning/mlr3verse_intro.qmd
+++ b/machine_learning/mlr3verse_intro.qmd
@@ -1,5 +1,11 @@
 ---
 title: "The mlr3verse framework"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 ```{r setup, include=FALSE}

--- a/machine_learning/models.qmd
+++ b/machine_learning/models.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Supervised Learning"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 ```{r setup, include=FALSE}

--- a/matrices.qmd
+++ b/matrices.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Matrices"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 ```{r setup, include=FALSE}

--- a/matrix_exercises.qmd
+++ b/matrix_exercises.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Matrix Exercises"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 output: 
   html_document:
     code_folding: "hide"

--- a/norm.qmd
+++ b/norm.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Working with distribution functions"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 ```{r setup, include=FALSE}

--- a/r_intro_mechanics.qmd
+++ b/r_intro_mechanics.qmd
@@ -1,4 +1,12 @@
-# R mechanics
+---
+title: "R mechanics"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
+---
 
 ```{r style, echo = FALSE, results = 'asis'}
 knitr::opts_chunk$set(

--- a/ranges_and_signals.qmd
+++ b/ranges_and_signals.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Genomic ranges and features"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 ```{r init, include=FALSE}

--- a/ranges_exercises.qmd
+++ b/ranges_exercises.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Ranges Exercises"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 format:
   html:
     code-fold: true

--- a/reading_and_writing.qmd
+++ b/reading_and_writing.qmd
@@ -1,6 +1,11 @@
 ---
 title: "Reading and writing data files"
-author: "Sean Davis"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 Almost no analysis starts inside R. Your data lives somewhere else first — an

--- a/single_cell/setup.qmd
+++ b/single_cell/setup.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Single-cell RNA-seq analysis"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 Bulk RNA-seq hands you one expression profile per sample — the average over every cell in the tube. But a tissue is not one cell type. Mash a piece of brain into a single average and you blur neurons, glia, and blood vessels into one indistinct smear. Single-cell RNA sequencing (scRNA-seq) measures gene expression one cell at a time, so instead of an average you get a catalog: which cell types are present, how many of each, and what makes each one distinct. That shift is what lets you discover a rare cell population, trace a developmental trajectory, or spot the cells that change in disease.

--- a/t-stats-and-tests.qmd
+++ b/t-stats-and-tests.qmd
@@ -1,5 +1,11 @@
 ---
 title: "The t-statistic and t-distribution"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 Suppose you measure a gene's expression in five treated samples and five

--- a/vectors.qmd
+++ b/vectors.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Vectors"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 ```{r setup, include=FALSE}

--- a/visualization_guide.qmd
+++ b/visualization_guide.qmd
@@ -1,5 +1,11 @@
 ---
 title: "A self-guided tour of data visualization in R"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
 ---
 
 ```{r setup, include=FALSE}


### PR DESCRIPTION
## What

Chapters without an explicit `author:` were inheriting the book-level author list (Sean Davis, Lori Shepherd Kern, Martin Morgan). Since Sean is the primary author of those, this adds a full author block (name, affiliation, url, email — matching `_quarto.yml`) to each such chapter/appendix.

- **28** chapters with a YAML `title:` → author block inserted.
- **4** chapters that used an `# H1` title with no frontmatter (`intro_to_rstudio`, `r_intro_mechanics`, `ai_tools`, `git_and_github`) → H1 converted to a YAML `title:` + author block, so the byline renders and frontmatter is consistent book-wide.
- **2** chapters with a bare `author: "Sean Davis"` (`reading_and_writing`, `biology_primer`) → replaced with the full block.

## Left untouched (intentionally)

Chapters already crediting co-authors/others (`factors`, `r_basics`, `dplyr_intro_msleep`, `control_statements`, `packages_and_dice`, `comparison_options`, `rproj_and_save_load`), plus the preface (`index`), `license`, `references`, and the part-divider pages.

## CI note

Editing frontmatter invalidates each chapter's freeze, so CI will re-execute these chapters. With Zenodo/ENCODE downloads now removed, the remaining data reads hit reliable sources (GitHub, NCBI GEO, Bioconductor hubs). Diff is purely the 34 `.qmd` frontmatters — no freeze churn committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)