### PR TITLE
Add CITATION.cff, README, and citation metadata (DOI to follow)

### DIFF
--- a/.quartoignore
+++ b/.quartoignore
@@ -1,3 +1,4 @@
 # Files Quarto should not treat as part of the book render.
 # Attribution/record-keeping markdown that is not a chapter:
 images/README.md
+README.md

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Sean
     email: seandavi@gmail.com
     affiliation: "University of Colorado Anschutz School of Medicine"
-    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: add Sean's ORCID
+    orcid: "https://orcid.org/0000-0002-8991-6458"
 abstract: >-
   A collection of chapters teaching introductory R, statistics, and
   Bioconductor for biologists and others coming to data science for the
@@ -28,6 +28,7 @@ preferred-citation:
   authors:
     - family-names: Davis
       given-names: Sean
+      orcid: "https://orcid.org/0000-0002-8991-6458"
   year: 2026
   url: "https://seandavi.github.io/RBiocBook"
   # doi: "10.5281/zenodo.XXXXXXX"  # TODO: add the Zenodo concept DOI after the first release

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,35 @@
+cff-version: 1.2.0
+title: "The RBioc Book"
+message: "If you use this book, please cite it using the metadata below."
+type: software
+authors:
+  - family-names: Davis
+    given-names: Sean
+    email: seandavi@gmail.com
+    affiliation: "University of Colorado Anschutz School of Medicine"
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: add Sean's ORCID
+abstract: >-
+  A collection of chapters teaching introductory R, statistics, and
+  Bioconductor for biologists and others coming to data science for the
+  first time.
+keywords:
+  - R
+  - Bioconductor
+  - statistics
+  - data science
+  - genomics
+  - teaching
+license: CC0-1.0
+url: "https://seandavi.github.io/RBiocBook"
+repository-code: "https://github.com/seandavi/RBiocBook"
+preferred-citation:
+  type: book
+  title: "The RBioc Book"
+  authors:
+    - family-names: Davis
+      given-names: Sean
+  year: 2026
+  url: "https://seandavi.github.io/RBiocBook"
+  # doi: "10.5281/zenodo.XXXXXXX"  # TODO: add the Zenodo concept DOI after the first release
+# version and date-released are intentionally omitted until the first
+# tagged release; add them (and the DOI above) when the release is cut.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# The RBioc Book
+
+[**The RBioc Book**](https://seandavi.github.io/RBiocBook) — a [Quarto](https://quarto.org/)
+book teaching introductory R, statistics, and Bioconductor for biologists and
+others coming to data science for the first time.
+
+📖 **Read it online:** <https://seandavi.github.io/RBiocBook>
+
+## Building locally
+
+The book is rendered with the `knitr` engine, so rendering executes the R in each
+chapter — you need R with the packages declared in `DESCRIPTION`.
+
+```sh
+quarto render            # all formats (html, pdf, epub) into _book/
+quarto preview           # live-reload server while editing
+quarto render <file>.qmd --to html   # single chapter, fast iteration
+```
+
+## Citing
+
+If you use this book, please cite it. A machine-readable citation is in
+[`CITATION.cff`](CITATION.cff) — GitHub turns it into a **"Cite this repository"**
+button (with APA and BibTeX export).
+
+<!-- After the first Zenodo release, replace the line below with the DOI badge:
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX)
+-->
+
+> Davis, S. *The RBioc Book*. <https://seandavi.github.io/RBiocBook>
+
+## License
+
+Released under [CC0 1.0](license.qmd) — a public-domain dedication. Use it freely.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -19,7 +19,11 @@ author:
     affiliation: Roswell Park Comprehensive Cancer Center<br/>Bioconductor Core Team
     affiliation-url: https://www.roswellpark.org/
 citation:
+  type: book
+  title: "The RBioc Book"
+  author: "Sean Davis"
   url: https://seandavi.github.io/RBiocBook
+  # doi: 10.5281/zenodo.XXXXXXX   # add the Zenodo concept DOI after the first release
 date: "2024-06-01"
 date-modified: 'last-modified'
 description: |


### PR DESCRIPTION
## What

Makes the book formally citable, ahead of minting a Zenodo DOI. Decisions: cite as a **book**, author **Sean Davis** (sole), files-first (DOI backfilled after the first release).

- **`CITATION.cff`** — machine-readable citation; gives GitHub's "Cite this repository" button (APA/BibTeX) and is read by Zenodo at release time. CC0. `orcid` and the Zenodo concept `doi` are left as clearly-marked TODO comments; `version`/`date-released` omitted until the first tagged release.
- **`README.md`** — the repo had none. Short overview, local-build instructions, a **Citing** section pointing at `CITATION.cff`, a commented DOI-badge placeholder, and the license. Excluded from the Quarto render via `.quartoignore`.
- **`_quarto.yml`** — fleshed out the `citation:` block (`type: book`, title, `author: Sean Davis`, url) with a DOI placeholder, so Quarto's rendered "how to cite" matches.

## Remaining (manual / external — needs your login)

1. Enable the **Zenodo ↔ GitHub** integration for `seandavi/RBiocBook`.
2. Cut a GitHub **release** (e.g. `v0.1.0`) → Zenodo mints the concept + version DOI.
3. I backfill the **concept DOI** into `CITATION.cff`, `_quarto.yml`, and the README badge (and add your ORCID).

🤖 Generated with [Claude Code](https://claude.com/claude-code)