### PR TITLE
Backfill Zenodo DOI; type the deposit as a book

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,7 @@
   "upload_type": "publication",
   "publication_type": "book",
   "title": "The RBioc Book",
-  "description": "A collection of chapters teaching introductory R, statistics, and Bioconductor for biologists and others coming to data science for the first time.",
+  "description": "The RBioc Book is an open-access, executable textbook that teaches introductory R programming, statistics, and Bioconductor to biologists and other researchers coming to data science for the first time. Written as a Quarto book with runnable R code in every chapter, it covers the R language and the RStudio environment, data structures, data wrangling with the tidyverse (dplyr), exploratory data analysis and visualization with ggplot2, statistical inference and hypothesis testing, clustering, and machine learning, alongside a hands-on tour of genomics and bioinformatics workflows in Bioconductor - including SummarizedExperiment, GenomicRanges, gene-expression analysis from the Gene Expression Omnibus (GEO), DNA methylation and epigenetic clocks, ChIP-seq, ATAC-seq, single-cell RNA-seq, and microbiome data. It also includes a primer on common biological assays for readers without a biology background. Designed for self-directed adult learners and usable as a course companion, the book is released into the public domain under CC0.",
   "creators": [
     {
       "name": "Davis, Sean",
@@ -14,10 +14,32 @@
   "license": "CC0-1.0",
   "keywords": [
     "R",
+    "R programming",
+    "RStudio",
     "Bioconductor",
+    "bioinformatics",
+    "genomics",
     "statistics",
     "data science",
-    "genomics",
-    "teaching"
+    "data visualization",
+    "ggplot2",
+    "tidyverse",
+    "dplyr",
+    "exploratory data analysis",
+    "machine learning",
+    "RNA-seq",
+    "single-cell RNA-seq",
+    "ChIP-seq",
+    "ATAC-seq",
+    "DNA methylation",
+    "epigenetics",
+    "microbiome",
+    "gene expression",
+    "GenomicRanges",
+    "SummarizedExperiment",
+    "reproducible research",
+    "teaching",
+    "education",
+    "open educational resource"
   ]
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,23 @@
+{
+  "upload_type": "publication",
+  "publication_type": "book",
+  "title": "The RBioc Book",
+  "description": "A collection of chapters teaching introductory R, statistics, and Bioconductor for biologists and others coming to data science for the first time.",
+  "creators": [
+    {
+      "name": "Davis, Sean",
+      "orcid": "0000-0002-8991-6458",
+      "affiliation": "University of Colorado Anschutz School of Medicine"
+    }
+  ],
+  "access_right": "open",
+  "license": "CC0-1.0",
+  "keywords": [
+    "R",
+    "Bioconductor",
+    "statistics",
+    "data science",
+    "genomics",
+    "teaching"
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,6 +22,9 @@ keywords:
 license: CC0-1.0
 url: "https://seandavi.github.io/RBiocBook"
 repository-code: "https://github.com/seandavi/RBiocBook"
+version: "2026.06.06"
+date-released: "2026-06-06"
+doi: "10.5281/zenodo.20574829"
 preferred-citation:
   type: book
   title: "The RBioc Book"
@@ -31,6 +34,4 @@ preferred-citation:
       orcid: "https://orcid.org/0000-0002-8991-6458"
   year: 2026
   url: "https://seandavi.github.io/RBiocBook"
-  # doi: "10.5281/zenodo.XXXXXXX"  # TODO: add the Zenodo concept DOI after the first release
-# version and date-released are intentionally omitted until the first
-# tagged release; add them (and the DOI above) when the release is cut.
+  doi: "10.5281/zenodo.20574829"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The RBioc Book
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20574829.svg)](https://doi.org/10.5281/zenodo.20574829)
+
 [**The RBioc Book**](https://seandavi.github.io/RBiocBook) — a [Quarto](https://quarto.org/)
 book teaching introductory R, statistics, and Bioconductor for biologists and
 others coming to data science for the first time.
@@ -23,11 +25,11 @@ If you use this book, please cite it. A machine-readable citation is in
 [`CITATION.cff`](CITATION.cff) — GitHub turns it into a **"Cite this repository"**
 button (with APA and BibTeX export).
 
-<!-- After the first Zenodo release, replace the line below with the DOI badge:
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX)
--->
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20574829.svg)](https://doi.org/10.5281/zenodo.20574829)
 
-> Davis, S. *The RBioc Book*. <https://seandavi.github.io/RBiocBook>
+The DOI above is the *concept* DOI — it always resolves to the latest version.
+
+> Davis, S. *The RBioc Book*. <https://doi.org/10.5281/zenodo.20574829>
 
 ## License
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -23,7 +23,7 @@ citation:
   title: "The RBioc Book"
   author: "Sean Davis"
   url: https://seandavi.github.io/RBiocBook
-  # doi: 10.5281/zenodo.XXXXXXX   # add the Zenodo concept DOI after the first release
+  doi: 10.5281/zenodo.20574829
 date: "2024-06-01"
 date-modified: 'last-modified'
 description: |

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -133,6 +133,8 @@ book:
         href: about.qmd
       - text: "License"
         href: license.qmd
+      - text: "DOI: 10.5281/zenodo.20574829"
+        href: https://doi.org/10.5281/zenodo.20574829
 
 bibliography:
   - references.bib

--- a/about.qmd
+++ b/about.qmd
@@ -69,7 +69,16 @@ learning philosophy behind the book.
 
 ## Citing the book
 
-If you use this material, a citation back to
-[seandavi.github.io/RBiocBook](https://seandavi.github.io/RBiocBook) is
-appreciated. The book is a living document; chapters are added and revised over
-time.
+If you use this material, a citation is appreciated. The book is archived on
+Zenodo with a DOI:
+
+> Davis, S. *The RBioc Book*. <https://doi.org/10.5281/zenodo.20574829>
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20574829.svg)](https://doi.org/10.5281/zenodo.20574829)
+
+That DOI ([10.5281/zenodo.20574829](https://doi.org/10.5281/zenodo.20574829)) is
+the *concept* DOI — it always resolves to the latest version, and each release
+also gets its own version-specific DOI. A machine-readable citation lives in the
+repository's [`CITATION.cff`](https://github.com/seandavi/RBiocBook/blob/main/CITATION.cff)
+(GitHub's "Cite this repository" button exports APA and BibTeX). The book is a
+living document; chapters are added and revised over time.


### PR DESCRIPTION
## What

The `2026.06.06` release minted a Zenodo DOI ([record 20574830](https://zenodo.org/records/20574830)). This backfills it and fixes the deposit type.

- **Concept DOI `10.5281/zenodo.20574829`** (always resolves to the latest version) added to `CITATION.cff` (top-level + `preferred-citation`), the `_quarto.yml` `citation:` block, and the `README` (top badge + Citing-section badge + citation line).
- `CITATION.cff` now carries `version: "2026.06.06"` and `date-released: 2026-06-06` matching the release.
- **`.zenodo.json`** added so future releases are typed as a **Publication / book**, not software. (Zenodo defaults GitHub releases to "software" and also read `CITATION.cff`'s top-level `type` — which the CFF spec restricts to `software`/`dataset`; `.zenodo.json` overrides with `upload_type=publication`, `publication_type=book`.)

## Manual follow-up (your Zenodo login)

The **existing** `v2026.06.06` record was created before `.zenodo.json` existed, so it still shows as *software*. Retype it once in the Zenodo UI: open [the record](https://zenodo.org/records/20574830) → **Edit** → Upload type → **Publication → Book** → **Save/Publish**. All later releases inherit the book type automatically from `.zenodo.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)