### PR TITLE
Content cleanup of the four ranges chapters

### DIFF
--- a/atac-seq/atac-seq.qmd
+++ b/atac-seq/atac-seq.qmd
@@ -40,6 +40,7 @@ ATAC-seq mini-analysis.
 - `r Biocpkg('GenomicAlignments')`
 - `r Biocpkg('rtracklayer')`
 - `r Biocpkg('heatmaps')`
+- `r Biocpkg('TxDb.Hsapiens.UCSC.hg19.knownGene')` (a large annotation download; install once with `BiocManager::install()`)
 
 ## What you'll learn
 
@@ -58,9 +59,9 @@ After working through this chapter, you'll be able to:
 ## Background
 
 Chromatin accessibility assays measure the extent to which DNA is open and accessible.
-Such assays now use high throughput sequencing as a quantitative readout. DNAse assays, first using microarrays[@Crawford2006-nt] and then DNAse-Seq [@Crawford2006-bk], requires a larger amount of DNA and is labor-indensive and has been largely supplanted by ATAC-Seq [@Buenrostro2013-dz]. 
+Such assays now use high throughput sequencing as a quantitative readout. DNase assays — first using microarrays [@Crawford2006-nt] and then DNase-seq [@Crawford2006-bk] — require more input DNA and are labor-intensive, and have been largely supplanted by ATAC-seq [@Buenrostro2013-dz].
 
-The Assay for Transposase Accessible Chromatin with high-throughput sequencing (ATAC-seq) method maps chromatin accessibility genome-wide. This method quantifies DNA accessibility with a hyperactive Tn5 transposase that cuts and inserts sequencing adapters into regions of chromatin that are accessible. High throughput sequencing of fragments produced by the process map to regions of increased accessibility, transcription factor binding sites, and nucleosome positioning. The method is both fast and sensitive and can be used as a replacement for DNAse _and_ MNase. 
+The Assay for Transposase Accessible Chromatin with high-throughput sequencing (ATAC-seq) method maps chromatin accessibility genome-wide. This method quantifies DNA accessibility with a hyperactive Tn5 transposase that cuts and inserts sequencing adapters into regions of chromatin that are accessible. High-throughput sequencing of the fragments produced maps these to regions of increased accessibility, transcription-factor binding sites, and nucleosome positioning. The method is both fast and sensitive and can be used as a replacement for DNase _and_ MNase.
 
 
 An early review of chromatin accessibility assays [@Tsompana2014-yh] compares the use cases, pros and cons, and expected signals from each of the most common approaches (@fig-chromatin-assays).
@@ -72,7 +73,7 @@ An early review of chromatin accessibility assays [@Tsompana2014-yh] compares th
 knitr::include_graphics("imgs/chromatin_accessibility_buck.png")
 ```
 
-The first manuscript describing the ATAC-seq protocol showed how ATAC-seq data "line up" with other data types such as ChIP-seq and DNase-seq (@fig-greenleaf-multimodal). It also highlighted how fragment length correlates with specific genomic regions and characteristics [@Buenrostro2013-dz, Figure 3].
+The first manuscript describing the ATAC-seq protocol showed how ATAC-seq data "line up" with other data types such as ChIP-seq and DNase-seq (@fig-greenleaf-multimodal). It also highlighted how fragment length correlates with specific genomic regions and characteristics [@Buenrostro2013-dz, Figure 2].
 
 ```{r}
 #| label: fig-greenleaf-multimodal
@@ -114,12 +115,12 @@ The _Bioconductor_ project includes several infrastructure packages for dealing 
 | Package  | Use cases |
 |---|---|
 | `r Biocpkg('Rsamtools')`  | low level access to FASTQ, VCF, SAM, BAM, BCF formats   |
-| `r Biocpkg('GenomicRanges')`  | Container and methods for handling genomic reagions   |
+| `r Biocpkg('GenomicRanges')`  | Container and methods for handling genomic regions   |
 | `r Biocpkg('GenomicFeatures')`  | Work with transcript databases, gff, gtf and BED formats  |
 | `r Biocpkg('GenomicAlignments')` | Reader for BAM format |
 | `r Biocpkg('rtracklayer')` | import and export multiple UCSC file formats including BigWig and Bed |
 
-Table: Commonly used Bioconductor and their high-level use cases.
+Table: Commonly used Bioconductor packages and their high-level use cases.
 
 As noted above, the output of an ATAC-seq experiment is a BAM file. Because paired-end sequencing is the standard for ATAC-seq, `readGAlignmentPairs()` is the right function to read it.
 
@@ -275,11 +276,8 @@ Because active promoters are nucleosome-free right at the transcription start si
 
 We loaded the BAM file with insert sizes (`isize`), so we can read fragment lengths straight off that column. The insert size is the same (in absolute value) for the `first` and `second` read of a pair, so we'll just use `first`.
 
-```{r results='hide'}
-GenomicAlignments::first(greenleaf)
-mcols(GenomicAlignments::first(greenleaf))
-class(mcols(GenomicAlignments::first(greenleaf)))
-head(mcols(GenomicAlignments::first(greenleaf))$isize)
+```{r}
+# Pull the insert size (fragment length) off the first read of each pair.
 fraglengths <- abs(mcols(GenomicAlignments::first(greenleaf))$isize)
 ```
 
@@ -288,7 +286,7 @@ Now we can look at the distribution of fragment lengths. The `density()` functio
 ```{r}
 #| label: fig-fraglength-density
 #| fig-cap: "Fragment-length (insert-size) density for our ATAC-seq reads."
-plot(density(fraglengths, bw = 0.05), xlim = c(0, 1000))
+plot(density(fraglengths), xlim = c(0, 1000))
 ```
 
 A `ggplot2` version of the same distribution (@fig-fraglength-ggplot) makes the periodic structure easier to read:
@@ -432,14 +430,7 @@ If you work extensively with ATAC-seq, Thomas Carroll's workshop is an excellent
 
 Feel free to work through it. The `r Biocpkg('ATACseqQC')` package vignette also offers a great deal beyond quality control, and several more ATAC-seq packages are available in _Bioconductor_.
 
-## MACS2 {.unnumbered}
-
-The MACS2 package is a commonly-used package for calling peaks. Installation
-and other details are available[^macs].
-
-[^macs]: https://github.com/taoliu/MACS
-
-```
-pip install macs2
-```
+Calling peaks on the coverage itself — finding the significant pileups rather than
+just plotting them — is most often done outside R with
+[MACS](https://github.com/macs3-project/MACS) (`pip install macs2`).
 

--- a/genomic_ranges.qmd
+++ b/genomic_ranges.qmd
@@ -58,86 +58,36 @@ fewer thing to track once you stay inside Bioconductor.
 ```{r loadlib}
 library(GenomicRanges)
 ```
-The Bioconductor `r Biocpkg("GenomicRanges")` package is a comprehensive toolkit designed to handle and manipulate genomic intervals and variables systematized on these intervals [@lawrence_software_2013]. Developed by Bioconductor, this package simplifies the complexity of managing genomic data, facilitating the efficient exploration, manipulation, and visualization of such data. GenomicRanges aids in dealing with the challenges of genomic data, including its massive size, intricate relationships, and high dimensionality.
+The Bioconductor `r Biocpkg("GenomicRanges")` package [@lawrence_software_2013]
+gives you the `GRanges` container for genomic intervals together with a vocabulary
+of fast operations on them — subsetting, resizing, overlap, nearest-neighbor, and
+genome arithmetic. The rest of this chapter introduces both by example, building
+small objects by hand so you can see exactly what each operation does.
 
-The GenomicRanges package in Bioconductor covers a wide range of use cases related to the management and analysis of genomic data. Here are some key examples:
+`GRanges` is built on R's **S4** class system, so each object carries dedicated
+slots — `seqnames`, `ranges`, `strand`, and metadata — with methods that operate
+on them. Three related containers show up throughout the chapter:
 
-* Genomic Feature Manipulation
-  : The GenomicRanges and GRanges classes can be used to represent and manipulate various genomic features such as genes, transcripts, exons, or single-nucleotide polymorphisms (SNPs). Users can query, subset, resize, shift, or sort these features based on their genomic coordinates.
-* Genomic Interval Operations
-  : The GenomicRanges package provides functions for performing operations on genomic intervals, such as finding overlaps, nearest neighbors, or disjoint intervals. These operations are fundamental to many types of genomic data analyses, such as identifying genes that overlap with ChIP-seq peaks, or finding variants that are in close proximity to each other.
-* Alignments and Coverage
-  : The GAlignments and GAlignmentPairs classes can be used to represent alignments of sequencing reads to a reference genome, such as those produced by a read aligner. Users can then compute coverage of these alignments over genomic ranges of interest, which is a common task in RNA-seq or ChIP-seq analysis.
-* Annotation and Metadata Handling
-  : The metadata column of a GRanges object can be used to store various types of annotation data associated with genomic ranges, such as gene names, gene biotypes, or experimental scores. This makes it easy to perform analyses that integrate genomic coordinates with other types of biological information.
-* Genome Arithmetic
-  : The GenomicRanges package supports a version of "genome arithmetic", which includes set operations (union, intersection, set difference) as well as other operations (like coverage, complement, or reduction) that are adapted to the specificities of genomic data.
-* Efficient Data Handling
-  : The CompressedGRangesList class provides a space-efficient way to represent a large list of GRanges objects, which is particularly useful when working with large genomic datasets, such as whole-genome sequencing data.
+| Class | What it holds | Typical use |
+|-------|---------------|-------------|
+| `GRanges` | a set of genomic ranges plus metadata | ChIP-seq peaks, CpG islands, genes |
+| `GRangesList` | a list of `GRanges` objects | exons grouped by transcript |
+| `IRanges` | plain integer ranges | the building block inside a `GRanges` |
 
-The GenomicRanges package in Bioconductor uses the S4 class system (see @tbl-genomic-ranges-classes), which is a part of the methods package in R. The S4 system is a more rigorous and formal approach to object-oriented programming in R, providing enhanced capabilities for object design and function dispatch.
+: The containers used in this chapter. {#tbl-genomic-ranges-classes}
 
-|Class Name           |Description                                                                     |Potential Use |
-|---------------------|--------------------------------------------------------------------------------|------|
-|GRanges              |Represents a collection of genomic ranges and associated variables.             |ChipSeq peaks, CpG islands, etc. |
-|GRangesList          |Represents a list of GenomicRanges objects.                                     |transcript models (exons, introns) |
-|RangesList           |Represents a list of Ranges objects.                                            |  |
-|IRanges              |Represents a collection of integer ranges.                                      |used mainly to *build* GRanges, etc. |
-|GPos                 |Represents genomic positions.                                                   |SNPs or other single-nucleotide locations |
-|GAlignments          |Represents alignments against a reference genome.                               |Sequence read locations from a BAM file |
-|GAlignmentPairs      |Represents pairs of alignments, typically representing a single fragment of DNA.|Paired-end sequence alignments |
-
-: Classes within the GenomicRanges package. Each class has a slightly different use case.  {#tbl-genomic-ranges-classes}{tbl-colwidths="[20,40,40]"}
-
-In the context of the GenomicRanges package, the S4 class system allows for the creation of complex, structured data objects that can effectively encapsulate genomic intervals and associated data. This system enables the package to handle the complexity and intricacy of genomic data.
-
-For example, the GenomicRanges class in the package is an S4 class that combines several basic data types into a composite object. It includes slots for sequence names (seqnames), ranges (start and end positions), strand information, and metadata. Each slot in the S4 class corresponds to a specific component of the genomic data, and methods (see @tbl-single-granges-methods and @tbl-multiple-granges-methods) can be defined to interact with these slots in a structured and predictable way.
-
-| **Method**            | **Description**                                                                         |
-|-----------------------|-----------------------------------------------------------------------------------------|
-| **length**            | Returns the number of ranges in the GRanges object.                                     |
-| **seqnames**          | Retrieves the sequence names of the ranges.                                             |
-| **ranges**            | Retrieves the start and end positions of the ranges.                                    |
-| **strand**            | Retrieves the strand information of the ranges.                                         |
-| **elementMetadata**   | Retrieves the metadata associated with the ranges.                                      |
-| **seqlevels**         | Returns the levels of the factor that the seqnames slot is derived from.                |
-| **seqinfo**           | Retrieves the Seqinfo (sequence information) object associated with the GRanges object. |
-| **start, end, width** | Retrieve or set the start or end positions, or the width of the ranges.                 |
-| **resize**            | Resizes the ranges.                                                                     |
-| **subset, [, [[, $**  | Subset or extract elements from the GRanges object.                                     |
-| **sort**              | Sorts the GRanges object.                                                               |
-| **shift**             | Shifts the ranges by a certain number of base pairs.                                    |
-
-: Methods for accessing, manipulating single objects {#tbl-single-granges-methods}
-
-The S4 class system also supports inheritance, which allows for the creation of specialized subclasses that share certain characteristics with a parent class but have additional features or behaviors.
-
-The S4 system's formalism and rigor make it well-suited to the complexities of bioinformatics and genomic data analysis. It allows for the creation of robust, reliable code that can handle complex data structures and operations, making it a key part of the GenomicRanges package and other Bioconductor packages.
-
-
-
-| **Method**            | **Description**                                                                         |
-|-----------------------|-----------------------------------------------------------------------------------------|
-| **findOverlaps**      | Finds overlaps between different sets of ranges.                                        |
-| **countOverlaps**     | Counts overlaps between different sets of ranges.                                       |
-| **subsetByOverlaps**  | Subsets the ranges based on overlaps.                                                   |
-| **distanceToNearest** | Computes the distance to the nearest range in another set of ranges.                    |
-
-: Methods for comparing and combining multiple GenomicRanges-class objects {#tbl-multiple-granges-methods}
-
-
-
-
-
-
+A compact cheat-sheet of the accessor and operation methods is collected under
+[Quick reference](#sec-granges-methods) at the end of the chapter; we meet each one
+in context first.
 
 To get going, we can construct a `GRanges` object by hand as an example.
 
 The `GRanges` class represents a collection of genomic ranges that each have a single start
 and end location on the genome. It can be used to store the location of genomic features
 such as contiguous binding sites, transcripts, and exons. These objects can be created by
-using the GRanges constructor function. The following code just creates a `GRanges` object 
-from scratch.
+using the GRanges constructor function. The following code creates one from scratch. (The `Rle()` calls in it simply
+repeat each value a given number of times — a compact "run-length" shorthand we
+return to under *coverage* later.)
 
 ```{r mkexample}
 gr <- GRanges(
@@ -191,7 +141,7 @@ class(mcols(gr))
 mcols(gr)
 ```
 
-Since the `class` of `mcols(gr)` is `r class(mcols(gr))`, we can use our `DataFrame` approaches to 
+Since the `class` of `mcols(gr)` is `r class(mcols(gr))`, we can use the `DataFrame` (Bioconductor's data-frame-like table) approaches to
 work with the data.
 
 ```{r mcols-df-methods}
@@ -268,7 +218,7 @@ tail(gr,n=2)
 #### Intra-range methods
 
 The methods described in this section work *one-region-at-a-time* and are, therefore, called
-"intra-region" methods. Methods that work across all regions are described below 
+"intra-range" methods. Methods that work across all regions are described below 
 in the [Inter-range methods] section.
 
 The `GRanges` class has accessors for the "ranges" part of the data. For example:
@@ -402,8 +352,8 @@ GenomicRanges::intersect(g, g2)
 GenomicRanges::setdiff(g, g2)
 ```
 
-There is extensive additional help available or by looking at the vignettes
-in at the `r Biocpkg("GenomicRanges")` pages.
+There is extensive additional help in the vignettes at the
+`r Biocpkg("GenomicRanges")` pages.
 
 ```{r helppagesgr,eval=FALSE}
 ?GRanges
@@ -419,7 +369,7 @@ methods(class="GRanges")
 
 ## GRangesList
 
-Some important genomic features, such as spliced transcripts that are are comprised of exons,
+Some important genomic features, such as spliced transcripts that are comprised of exons,
 are inherently compound structures. Such a feature makes much more sense when expressed
 as a compound object such as a GRangesList. If we think of each transcript as a set of exons,
 each transcript would be summarized as a `GRanges` object. However, if we have multiple transcripts,
@@ -427,7 +377,7 @@ we want to keep them separate, with each transcript holding its own exons. A `GR
 is a list of `GRanges` objects. Continuing with the transcripts idea, a `GRangesList`
 can contain all the transcripts and their exons; each transcript is one element in the list.
 
-![The structure of a GRangesList, which is a `list` of GRanges objects. While the analogy is not perfect, a `GRangesList` behaves a bit like a list. Each element in the `GRangesList` *is* a `Granges` object. A common use case for a `GRangesList` is to store a list of transcripts, each of which have exons as the regions in the `GRanges`. ](images/granges_list_structure.png){#fig-granges-list-structure}
+![The structure of a GRangesList, which is a `list` of GRanges objects. While the analogy is not perfect, a `GRangesList` behaves a bit like a list. Each element in the `GRangesList` *is* a `GRanges` object. A common use case for a `GRangesList` is to store a list of transcripts, each of which have exons as the regions in the `GRanges`. ](images/granges_list_structure.png){#fig-granges-list-structure}
 
 
 Whenever genomic features consist of multiple
@@ -544,9 +494,8 @@ gr1[queryHits(overlaps)]
 gr2[subjectHits(overlaps)]
 ```
 
-As you might expect, the `countOverlaps` method counts the regions in the
-second `GRanges` that overlap with those that overlap
-with each element of the first.
+As you might expect, the `countOverlaps` method counts, for each range in the
+first `GRanges`, how many ranges in the second it overlaps.
 
 ```{r countoverlaps}
 countOverlaps(gr1, gr2)
@@ -652,6 +601,7 @@ chapter apply directly.
 ![A graphical representation of range operations demonstrated on a gene model.](images/range_operations_diagram.png){#fig-range-operations}
 
 ```{r}
+# install once: BiocManager::install("TxDb.Hsapiens.UCSC.hg38.knownGene")
 library(TxDb.Hsapiens.UCSC.hg38.knownGene)
 txdb <- TxDb.Hsapiens.UCSC.hg38.knownGene
 ```
@@ -695,6 +645,38 @@ per transcript — use `exonsBy(txdb, by = "tx")`. That is the natural object fo
 counting reads per transcript and is exactly the `GRangesList` structure we built
 by hand earlier.
 :::
+
+## Quick reference: GRanges methods {#sec-granges-methods}
+
+Every method below was introduced by example earlier in the chapter; this is a
+compact place to look them back up.
+
+| Method | Description |
+|--------|-------------|
+| `length` | Number of ranges in the object. |
+| `seqnames` | Sequence (chromosome) names of the ranges. |
+| `ranges` | The start and end positions. |
+| `strand` | Strand of each range. |
+| `mcols` (a.k.a. `elementMetadata`) | The metadata columns. |
+| `seqlevels` | The set of possible sequence names. |
+| `seqinfo` | The `Seqinfo` (sequence names and lengths). |
+| `start`, `end`, `width` | Get or set the range bounds or width. |
+| `shift`, `resize`, `flank` | Reshape each range on its own (intra-range). |
+| `reduce`, `disjoin`, `gaps`, `coverage` | Summarize a set of ranges together (inter-range). |
+| `subset`, `[`, `[[`, `$` | Subset or extract elements. |
+| `sort` | Sort the ranges. |
+
+: Accessing and manipulating a single `GRanges`. {#tbl-single-granges-methods}
+
+| Method | Description |
+|--------|-------------|
+| `findOverlaps` | Find overlaps between two sets of ranges. |
+| `countOverlaps` | Count, per query range, how many subject ranges it overlaps. |
+| `subsetByOverlaps` | Keep only the query ranges that overlap the subject. |
+| `nearest`, `distanceToNearest` | Nearest subject range to each query (with distance). |
+
+: Comparing and combining two `GRanges` objects. {#tbl-multiple-granges-methods}
+
 
 ## Summary
 

--- a/genomic_ranges_chipseq.qmd
+++ b/genomic_ranges_chipseq.qmd
@@ -25,7 +25,7 @@ hand and worked through the full catalog of range operations (set operations,
 overlaps, nearest-feature searches, gene models) systematically. This chapter
 puts those tools to work on a **real dataset**, focusing on what a hand-built
 example can't show you: file formats, importing, and exploring an actual peak
-set. Here we keep our hands on real data.
+set.
 
 ## What you'll learn
 
@@ -77,10 +77,6 @@ yourself on the raw file and being off by one.
 ```{r setup, message=FALSE, warning=FALSE}
 library(rtracklayer)
 library(GenomicRanges)
-library(ggplot2)
-library(dplyr)
-
-theme_set(theme_minimal())
 ```
 
 ## Importing the CTCF peaks
@@ -128,8 +124,10 @@ columns of the `GRanges`, where you can reach them with `$`.
 
 ## Looking inside a GRanges
 
-A `GRanges` keeps the *ranges* (chromosome, start, end, strand) separate from the
-*metadata* (everything else). You pull each part out with an accessor function.
+You met these accessors in the previous chapter; here they are again, this time
+pulling information out of the peaks you just imported. The *ranges* (chromosome,
+start, end, strand) come out with their own accessors, and everything else (the
+*metadata*) comes out with `mcols()`.
 
 ```{r granges-accessors}
 length(ctcf_peaks)         # how many peaks?
@@ -139,8 +137,11 @@ head(end(ctcf_peaks))      # end positions
 head(width(ctcf_peaks))    # width = end - start + 1
 ```
 
-So this file contains `r length(ctcf_peaks)` CTCF peaks. The widths vary, but
-let's look at the whole distribution rather than the first six values:
+So this file contains `r length(ctcf_peaks)` CTCF peaks. Notice the comment on
+`width`: it is `end - start + 1`, not `end - start`. Because `GRanges` coordinates
+are 1-based and *inclusive*, both endpoints count — the very same span the 0-based
+BED file wrote as `end - start`. The widths vary, but let's look at the whole
+distribution rather than the first six values:
 
 ```{r peak-widths}
 #| label: fig-peak-widths
@@ -211,7 +212,7 @@ fixed-width windows are usually built around it.
 ```{r starts-ends}
 peak_starts  <- start(ctcf_peaks)
 peak_ends    <- end(ctcf_peaks)
-peak_centers <- start(ctcf_peaks) + width(ctcf_peaks) / 2
+peak_centers <- (start(ctcf_peaks) + end(ctcf_peaks)) / 2
 
 head(peak_centers, 5)
 ```
@@ -220,10 +221,10 @@ head(peak_centers, 5)
 
 ## Reshaping ranges
 
-Three functions cover most of the range-reshaping you'll do on a peak set:
-`shift()` slides a range, `resize()` changes its width, and `flank()` builds a
-neighbouring region. They all return a new `GRanges` and leave the original
-untouched.
+You met `shift()`, `resize()`, and `flank()` in the previous chapter. Here is what
+they do to a *real* peak set — the operations behind sliding a window, building
+fixed-width windows for motif analysis, and grabbing the DNA beside a peak. As
+before, each returns a new `GRanges` and leaves the original untouched.
 
 ### Shifting
 
@@ -269,7 +270,7 @@ upstream_1kb[1]
 ```
 
 The flanking range is the 1000 bp sitting immediately before the start of the
-first peak — the kind of window you might scan for a neighbouring promoter.
+first peak — the kind of window you might scan for a neighboring promoter.
 
 ::: {.callout-note}
 ## Overlaps and grouped operations: see the previous chapter
@@ -380,10 +381,10 @@ or function that does the job.
    ::: {.callout-note collapse="true"}
    ## Solution
    ```{r ex-centers, eval=FALSE}
-   centers <- start(ctcf_peaks) + width(ctcf_peaks) / 2
+   centers <- (start(ctcf_peaks) + end(ctcf_peaks)) / 2
    median(centers)
    ```
-   The center is the start plus half the width. (You could also use
+   The center is the midpoint of the start and end. (You could also use
    `start(resize(ctcf_peaks, width = 1, fix = "center"))` to let `GRanges` do the
    arithmetic.)
    :::

--- a/ranges_exercises.qmd
+++ b/ranges_exercises.qmd
@@ -15,7 +15,7 @@ format:
 
 ```{r init, include=FALSE}
 library(knitr)
-opts_chunk$set(cache=TRUE, message=FALSE)
+opts_chunk$set(cache=TRUE, message=FALSE, R.options=list(max.print=50))
 ```
 
 The two ranges chapters — *Genomic ranges and features* and *Genomic ranges with
@@ -93,7 +93,7 @@ strand, and a block of metadata columns.
 **What metadata is attached?** The per-range metadata lives in the `mcols`.
 
 ```{r}
-mcols(dnase)
+head(mcols(dnase))
 ```
 
 These columns are the extra fields from the original narrowPeak file — things like
@@ -104,7 +104,8 @@ never lose the link between a location and its data.
 every peak; `table()` tallies them.
 
 ```{r}
-table(seqnames(dnase))
+# Show the busiest 25 chromosomes; the full list includes many empty contigs.
+sort(table(seqnames(dnase)), decreasing = TRUE)[1:25]
 ```
 
 Each count is the number of DNase peaks called on that chromosome. Bigger
@@ -123,11 +124,12 @@ tight distribution around a couple hundred bp is typical for a DNase peak caller
 and the `seqlevelsStyle`, then switch the style to Ensembl and look again.
 
 ```{r}
-seqlevels(dnase)
+head(seqlevels(dnase), 25)   # first 25 of many contigs
+length(seqlevels(dnase))     # how many sequence names in all
 seqlevelsStyle(dnase)
 seqlevelsStyle(dnase) <- "ensembl"
 seqlevelsStyle(dnase)
-seqlevels(dnase)
+head(seqlevels(dnase), 25)   # same chromosomes, now in Ensembl style
 ```
 
 The object started in **UCSC** style (`chr1`, `chr2`, …). Assigning a new
@@ -138,7 +140,7 @@ ranges changed, only the labels.
 ::: {.callout-warning}
 ## The `chr` gotcha that silently returns zero overlaps
 
-`seqlevelsStyle` matters enormously the moment you compare two objects. Overlap
+`seqlevelsStyle` matters the moment you compare two objects. Overlap
 operations match on the *exact* sequence name, so a peak on `chr1` will **never**
 overlap a region on `1` — R reports zero overlaps and raises no error. If an
 overlap count comes back suspiciously at zero, the first thing to check is whether
@@ -224,12 +226,13 @@ expansion is symmetric, and call the result `dnase_wide`.
 ```{r}
 w <- width(dnase)
 dnase_wide <- resize(dnase, width = w + 100, fix = "center")
-width(dnase_wide)
+head(width(dnase_wide))             # first few widened peaks
+all(width(dnase_wide) == w + 100)   # every peak is exactly 100 bp wider
 ```
 
 `resize()` sets each range to a new width; `fix="center"` keeps the midpoint fixed
-so the peak grows 50 bp in each direction. Comparing `width(dnase_wide)` to the
-original widths confirms every peak is exactly 100 bp larger.
+so the peak grows 50 bp in each direction. The `all(...)` check confirms every
+peak ended up exactly 100 bp larger.
 
 ## Exercise 3: DNase sites relative to gene promoters
 
@@ -242,10 +245,9 @@ You'll need the `TxDb.Hsapiens.UCSC.hg19.knownGene` transcript database. If it
 isn't already installed, install it once (this is a one-time setup step, not part
 of the analysis):
 
-```
+```r
+# one-time setup, not part of the analysis
 BiocManager::install("TxDb.Hsapiens.UCSC.hg19.knownGene")
-library("TxDb.Hsapiens.UCSC.hg19.knownGene")
-kg <- TxDb.Hsapiens.UCSC.hg19.knownGene
 ```
 
 **Load the genes from the TxDb.** Attach the package, grab the `TxDb` object, and
@@ -268,7 +270,7 @@ of a gene, so flanking each gene by 2 kb on its upstream side gives a first
 approximation.
 
 ```{r}
-flank(gx, 2000)
+head(flank(gx, 2000))
 ```
 
 `flank()` returns a new range immediately upstream of each gene — strand-aware, so
@@ -342,11 +344,13 @@ caught and fixed. (`dnase2` was never reassigned, so it was UCSC-style all along
 Compare that expectation to what you observed.
 
 ```{r}
-prop_proms <- sum(width(prom_regions)) / sum(seqlengths(prom_regions))
-prop_dnase <- sum(width(dnase)) / sum(seqlengths(prom_regions))
-# Under independence, the expected number of DNase peaks landing in a
-# promoter is (fraction of genome that is promoter) times the number of peaks.
-prop_proms * prop_dnase * length(dnase)
+# Use one consistent genome size. Some contigs have unknown (NA) lengths,
+# so drop those when summing.
+genome_bp <- sum(as.numeric(seqlengths(gx)), na.rm = TRUE)
+prop_proms <- sum(width(prom_regions)) / genome_bp
+# Under independence, the expected number of DNase peaks landing in a promoter
+# is (fraction of the genome that is promoter) times the number of peaks.
+prop_proms * length(dnase)
 ```
 
 The expected-by-chance number is far smaller than the count you actually observed.
@@ -363,8 +367,9 @@ on. In this exercise you'll ask how much each mark **overlaps CpG islands** — 
 build a small reusable enrichment score along the way.
 
 The data again comes from `AnnotationHub`. ENCODE published these histone ChIP-seq
-peak calls as BED files; the hub serves them as `GRanges`. We've already found the
-right hub IDs, so you can load each mark directly.
+peak calls as BED files; the hub serves them as `GRanges`. Each mark's query
+matches several records, so to keep things moving we've already picked the right
+hub IDs and you can load each mark directly.
 
 ```{r}
 library(AnnotationHub)


### PR DESCRIPTION
Editorial pass over the four chapters reordered in #34 — correctness, clarity, language harmonization, and rendered-output styling. **Stacked on `reorg-ranges-chapters` (#34)**, since these edits target the renamed files; merge #34 first (or merge this into that branch).

Findings were gathered by a per-chapter review fan-out, then triaged.

## `ranges_exercises.qmd` — output-length styling (the main ask)
`code-fold: true` hides code but still renders output in full, so several chunks stretched for pages.
- `seqlevels(dnase)` (×2), `table(seqnames(dnase))`, `mcols(dnase)`, `flank(gx, 2000)`, `width(dnase_wide)` now show `head()` / `summary()` / a sorted slice / a `TRUE` check instead of dumping ~10⁴–10⁵ rows or the full hg19 contig list.
- Global safety net: `R.options=list(max.print=50)` in the init chunk.
- **Correctness:** the "expected by chance" calc dropped its stray `prop_dnase` factor (the code disagreed with its own comment and the surrounding prose) and now uses one consistent `na.rm` genome size.
- De-duplicated the TxDb install block; explained why the hub IDs are pre-supplied.

## `atac-seq.qmd`
- **`density(fraglengths, bw = 0.05)`** → default bandwidth (0.05 bp did no smoothing on bp-scale data, contradicting the "smoothed version" prose).
- **Figure number:** the fragment-length sentence now cites **Figure 2** (verified against the open-access PMC3959825; the "Figure 4" CTCF caption was already correct).
- Typos (labor-intensive, regions, DNase, "packages"); collapsed a dead `results='hide'` chunk; folded the orphaned post-Summary **MACS2** section into *Additional work*; added `TxDb.Hsapiens.UCSC.hg19.knownGene` to packages-used.

## `genomic_ranges.qmd` (foundations)
- Cut the promotional "comprehensive toolkit…" paragraph plus the irrelevant use-case bullets, 7-row class table, and S4-formalism prose from the cold open; replaced with a tight intro + a 3-row container table.
- Relocated the accessor/method tables into a **Quick reference** cheat-sheet right before the Summary (the reader meets each method by example first).
- Fixed the garbled `countOverlaps` sentence, `intra-region`→`intra-range`, and assorted typos; glossed `Rle`/`DataFrame`; added a TxDb install hint.

## `genomic_ranges_chipseq.qmd`
- **Peak center** → `(start + end)/2` (the old `start + width/2` was off by ~0.5 bp and disagreed with `resize(fix="center")`, the chapter's own canonical center op).
- Reconciled the `width = end - start + 1` comment with the 0-based BED explanation.
- Lightened the re-teaching of accessors and `shift`/`resize`/`flank` now that the foundations chapter owns them; dropped unused `dplyr`/`ggplot2` from setup.

## Notes
- Source/prose and a few code-display changes only; no analysis logic changed except the two flagged correctness fixes. CI will re-execute these chapters.
- Fence balance verified in all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)