### PR TITLE
ci: serialize workflow runs per ref (prevent stale gh-pages publishes)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,6 +12,16 @@ name: R-CMD-check
 
 permissions: read-all
 
+# Serialize runs per ref so a newer commit supersedes an older one. Without this,
+# two pushes to main close together (e.g. two PRs merged seconds apart) each run
+# `quarto publish gh-pages`, and whichever finishes last wins — so an older
+# commit's render can clobber a newer one's published site. Cancelling the
+# in-progress run on the same ref guarantees the newest commit is what publishes.
+# The ref-keyed group also coalesces rapid pushes to a single PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   R-CMD-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Each push to `main` runs the full `R-CMD-check` workflow, which ends with `quarto publish gh-pages` (a full-site replace). When two pushes land close together — e.g. PRs #36 and #37 merged ~2 seconds apart — both runs publish, and **whichever finishes last wins**. The #36-merge run (commit `9bccb4b`, which predates #37) published last and reverted `ranges_exercises.html` to its pre-blue-box state, even though `main` was correct.

## Fix

Add a workflow-level concurrency group:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

- On `main`, a newer push cancels the older in-progress run on the same ref, so **the newest commit is always what publishes** — an older render can't clobber a newer one.
- The ref-keyed group also coalesces rapid pushes to a single PR (older PR-commit runs get cancelled), saving CI minutes.

Validated that the workflow YAML still parses. No job logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)