### PR TITLE
Add multiome (paired) integration chapter + CI hardening

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,9 @@ Depends: magick, knitr, rmarkdown, pdftools, ggfortify, ggplot2,
     AnnotationHub, BiocStyle, ggparty, mlr3viz, mia, miaViz,
     curatedMetagenomicData, scater, ggtree, vegan, pheatmap, scales,
     UpSetR, RColorBrewer, patchwork, airway, data.table, lubridate, mlr3,
-    scran, scRNAseq, downlit, xml2
+    scran, scRNAseq, downlit, xml2,
+    SingleCellExperiment, MultiAssayExperiment, SingleCellMultiModal, Seurat,
+    Signac, EnsDb.Hsapiens.v86
 License: Artistic-2.0
 URL: https://github.com/seandavi/RBiocBook
 BugReports: https://support.bioconductor.org/tag/mypackage

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,25 @@ RUN apt-get update \
 # DESCRIPTION Depends: is the single source of truth, kept honest by
 # tools/check-deps.R. Version constraints are stripped with regex character
 # classes (no backslashes, so this survives every quoting layer).
+#
+# BiocManager::install() treats a failed *download* as a warning, not an error,
+# so a transient mirror hiccup (e.g. a 504 on one binary) would otherwise leave
+# a package missing while the build still exits 0 — a silently broken image.
+# Guard against that: retry only the still-missing packages a few times to ride
+# out transient failures, then HARD-FAIL the build if anything is still absent.
 COPY DESCRIPTION /tmp/DESCRIPTION
-RUN Rscript -e 'deps <- read.dcf("/tmp/DESCRIPTION")[1, "Depends"]; \
+RUN Rscript -e 'options(timeout = 600); \
+      deps <- read.dcf("/tmp/DESCRIPTION")[1, "Depends"]; \
       deps <- trimws(gsub("[(].*?[)]", "", strsplit(deps, ",")[[1]])); \
       deps <- deps[deps != "" & deps != "R"]; \
-      BiocManager::install(deps, update = FALSE, ask = FALSE, Ncpus = parallel::detectCores())' \
+      for (attempt in 1:3) { \
+        missing <- setdiff(deps, rownames(installed.packages())); \
+        if (!length(missing)) break; \
+        message(sprintf("Dependency install attempt %d: %d package(s) remaining", attempt, length(missing))); \
+        BiocManager::install(missing, update = FALSE, ask = FALSE, Ncpus = parallel::detectCores()); \
+      }; \
+      missing <- setdiff(deps, rownames(installed.packages())); \
+      if (length(missing)) stop(sprintf("Image build aborted: %d declared package(s) failed to install: %s", length(missing), paste(missing, collapse = ", ")))' \
   && rm /tmp/DESCRIPTION
 
 # Quarto CLI + TinyTeX (PDF) + quartobot (pre-render hook declared in _quarto.yml).

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -113,8 +113,7 @@ book:
         - ranges_exercises.qmd
         - atac-seq/atac-seq.qmd
         - single_cell/setup.qmd
-        # Draft — un-comment once analytical sections + deps are finalized:
-        #- single_cell/multiome.qmd                       # vertical (paired) integration
+        - single_cell/multiome.qmd                        # vertical (paired) integration
         #- single-cell-atac-and-rna-transfer-learning.qmd # diagonal (unpaired) label transfer — Commit 2
     # - part: "Single Cell"
     #   chapters:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -113,7 +113,9 @@ book:
         - ranges_exercises.qmd
         - atac-seq/atac-seq.qmd
         - single_cell/setup.qmd
-        #- single-cell-atac-and-rna-transfer-learning.qmd
+        # Draft — un-comment once analytical sections + deps are finalized:
+        #- single_cell/multiome.qmd                       # vertical (paired) integration
+        #- single-cell-atac-and-rna-transfer-learning.qmd # diagonal (unpaired) label transfer — Commit 2
     # - part: "Single Cell"
     #   chapters:
     #     - single_cell/setup.qmd

--- a/references.bib
+++ b/references.bib
@@ -576,3 +576,17 @@ year = {2011},
   abstract = {The mammalian cerebral cortex supports cognitive functions such as sensorimotor integration, memory, and social behaviors. Normal brain function relies on a diverse set of differentiated cell types, including neurons, glia, and vasculature. Here, we have used large-scale single-cell RNA sequencing (RNA-seq) to classify cells in the mouse somatosensory cortex and hippocampal CA1 region. We found 47 molecularly distinct subclasses, comprising all known major cell types in the cortex. We identified numerous marker genes, which allowed alignment with known cell types, morphology, and location. We found a layer I interneuron expressing Pax6 and a distinct postmitotic oligodendrocyte subclass marked by Itpr2. Across the diversity of cortical cell types, transcription factors formed a complex, layered regulatory code, suggesting a mechanism for the maintenance of adult cell type identity.},
   file = {/Users/davsean/Zotero/storage/T6FAYXRB/Zeisel et al. - 2015 - Cell types in the mouse cortex and hippocampus revealed by single-cell RNA-seq.pdf}
 }
+
+@article{argelaguet2021computational,
+  title = {Computational principles and challenges in single-cell data integration},
+  author = {Argelaguet, Ricard and Cuomo, Anna S. E. and Stegle, Oliver and Marioni, John C.},
+  year = {2021},
+  journal = {Nature Biotechnology},
+  volume = {39},
+  number = {10},
+  pages = {1202--1215},
+  publisher = {Nature Publishing Group},
+  doi = {10.1038/s41587-021-00895-7},
+  url = {https://www.nature.com/articles/s41587-021-00895-7},
+  abstract = {The rapid growth of single-cell omics technologies has produced a wealth of data probing distinct molecular layers. Integrating these heterogeneous datasets provides a holistic view of cellular state, but raises substantial computational challenges. This Review organizes single-cell data integration strategies along the axes of what is shared across datasets (anchors), distinguishing horizontal, vertical, diagonal and mosaic integration, and surveys methods and open problems for each.}
+}

--- a/references.bib
+++ b/references.bib
@@ -590,3 +590,75 @@ year = {2011},
   url = {https://www.nature.com/articles/s41587-021-00895-7},
   abstract = {The rapid growth of single-cell omics technologies has produced a wealth of data probing distinct molecular layers. Integrating these heterogeneous datasets provides a holistic view of cellular state, but raises substantial computational challenges. This Review organizes single-cell data integration strategies along the axes of what is shared across datasets (anchors), distinguishing horizontal, vertical, diagonal and mosaic integration, and surveys methods and open problems for each.}
 }
+
+@article{hao2021integrated,
+  title = {Integrated analysis of multimodal single-cell data},
+  author = {Hao, Yuhan and Hao, Stephanie and Andersen-Nissen, Erica and Mauck, William M. and Zheng, Shiwei and Butler, Andrew and Lee, Maddie J. and Wilk, Aaron J. and Darby, Charlotte and Zager, Michael and others},
+  year = {2021},
+  journal = {Cell},
+  volume = {184},
+  number = {13},
+  pages = {3573--3587.e29},
+  doi = {10.1016/j.cell.2021.04.048},
+  url = {https://doi.org/10.1016/j.cell.2021.04.048}
+}
+
+@article{stuart2021signac,
+  title = {Single-cell chromatin state analysis with Signac},
+  author = {Stuart, Tim and Srivastava, Avi and Madad, Shaista and Lareau, Caleb A. and Satija, Rahul},
+  year = {2021},
+  journal = {Nature Methods},
+  volume = {18},
+  number = {11},
+  pages = {1333--1341},
+  doi = {10.1038/s41592-021-01282-5},
+  url = {https://doi.org/10.1038/s41592-021-01282-5}
+}
+
+@article{cusanovich2015multiplex,
+  title = {Multiplex single-cell profiling of chromatin accessibility by combinatorial cellular indexing},
+  author = {Cusanovich, Darren A. and Daza, Riza and Adey, Andrew and Pliner, Hannah A. and Christiansen, Lena and Gunderson, Kevin L. and Steemers, Frank J. and Trapnell, Cole and Shendure, Jay},
+  year = {2015},
+  journal = {Science},
+  volume = {348},
+  number = {6237},
+  pages = {910--914},
+  doi = {10.1126/science.aab1601},
+  url = {https://doi.org/10.1126/science.aab1601}
+}
+
+@article{vandereyken2023methods,
+  title = {Methods and applications for single-cell and spatial multi-omics},
+  author = {Vandereyken, Katy and Sifrim, Alejandro and Thienpont, Bernard and Voet, Thierry},
+  year = {2023},
+  journal = {Nature Reviews Genetics},
+  volume = {24},
+  number = {8},
+  pages = {494--515},
+  doi = {10.1038/s41576-023-00580-2},
+  url = {https://doi.org/10.1038/s41576-023-00580-2}
+}
+
+@article{schep2017chromvar,
+  title = {{chromVAR}: inferring transcription-factor-associated accessibility from single-cell epigenomic data},
+  author = {Schep, Alicia N. and Wu, Beijing and Buenrostro, Jason D. and Greenleaf, William J.},
+  year = {2017},
+  journal = {Nature Methods},
+  volume = {14},
+  number = {10},
+  pages = {975--978},
+  doi = {10.1038/nmeth.4401},
+  url = {https://doi.org/10.1038/nmeth.4401}
+}
+
+@article{eckenrode2023curated,
+  title = {Curated single cell multimodal landmark datasets for {R}/{Bioconductor}},
+  author = {Eckenrode, Kelly B. and Righelli, Dario and Ramos, Marcel and Argelaguet, Ricard and Vanderaa, Christophe and Geistlinger, Ludwig and Culhane, Aedin C. and Gatto, Laurent and Carey, Vincent J. and Morgan, Martin and Risso, Davide and Waldron, Levi},
+  year = {2023},
+  journal = {PLOS Computational Biology},
+  volume = {19},
+  number = {8},
+  pages = {e1011324},
+  doi = {10.1371/journal.pcbi.1011324},
+  url = {https://doi.org/10.1371/journal.pcbi.1011324}
+}

--- a/single_cell/multiome.qmd
+++ b/single_cell/multiome.qmd
@@ -1,0 +1,151 @@
+---
+title: "Integrating single-cell ATAC and RNA"
+author:
+  - name: Sean Davis
+    url: https://seandavi.github.io/
+    affiliation: University of Colorado<br/>Anschutz School of Medicine
+    affiliation-url: https://medschool.cuanschutz.edu/
+    email: seandavi@gmail.com
+---
+
+A single-cell RNA experiment tells you what each cell *is doing*: which genes it is actively transcribing, right now, in the moment it was captured. A single-cell ATAC experiment tells you something different and complementary — which stretches of the genome are *open for business*. ATAC-seq finds the regions of chromatin a cell has unpacked from its tightly wound default state: promoters it has switched on, enhancers it is using, the regulatory switches it has flipped. Expression is the output; accessibility is the wiring that produces it. Measure only one and you are reading half the circuit.
+
+Why does the wiring matter if you can already see the output? Because a cell often opens a regulatory region *before*, or *without*, transcribing the gene it controls. A stem cell on the verge of becoming a blood cell can unlock the enhancers of blood-cell genes while those genes are still essentially silent — the chromatin is poised, the decision half-made, but the RNA hasn't caught up yet. Accessibility therefore carries information about a cell's *trajectory and regulatory state* that expression alone misses: which transcription factors are active, which enhancers drive which genes, where a cell is heading rather than only where it is.
+
+The technology that makes this concrete is the **multiome** assay (here, 10x Genomics' Single Cell Multiome ATAC + Gene Expression), which measures *both* RNA and open chromatin in the *same nucleus*. That "same nucleus" is the crucial part. With separate experiments you can only compare populations — the average RNA of one batch of cells against the average accessibility of another. With a multiome you can ask a cause-and-effect question inside a single cell: *this* enhancer is open, and *this* gene, which it controls, is expressed, in this very cell. That is what lets you move from cataloguing cell types to reconstructing the regulatory logic that defines them.
+
+This chapter is about **integration**: combining the two modalities into one coherent analysis instead of two parallel ones. We will build the intuition for what integration means, why it is harder than it sounds, and then do it hands-on with a public 10x PBMC multiome dataset that ships ready-to-use as a Bioconductor `MultiAssayExperiment`.
+
+## What you'll learn
+
+- Why chromatin accessibility (ATAC) and gene expression (RNA) are complementary readouts of the same cell, and what each one uniquely tells you.
+- The three shapes of single-cell integration — **vertical**, **diagonal**, and **mosaic** — and how knowing which one you have decides which methods apply.
+- The **feature-space problem**: RNA is measured over genes, ATAC over genomic peaks, and why that mismatch is the central obstacle to integration.
+- The **bridges** that connect the two spaces: gene-activity scores, peak-to-gene links, and transcription-factor motif activity.
+- How to load and explore a real multiome dataset as a `MultiAssayExperiment` of two `SingleCellExperiment`s, and process each modality on its own terms.
+- How to build a **joint embedding** that uses both modalities at once, and what it buys you over either modality alone.
+
+This chapter builds directly on the [single-cell RNA-seq chapter](setup.qmd) (the `SingleCellExperiment`, normalization, HVGs, PCA/UMAP, clustering) and on the [bulk ATAC-seq chapter](../atac-seq/atac-seq.qmd) (peaks, fragments, what accessibility *is*). If either is hazy, skim it first — we lean on both.
+
+## Two views of the same cell
+
+It helps to be precise about what each assay actually counts.
+
+- **scRNA-seq** counts transcripts and assigns them to **genes**. A cell becomes a vector of ~20,000–30,000 gene counts. High counts for a gene mean that gene is being transcribed.
+- **scATAC-seq** counts sequencing fragments that fall in accessible chromatin and assigns them to **peaks** — genomic intervals (typically a few hundred base pairs) that are open across many cells. A cell becomes a vector of counts over ~100,000+ peaks. A nonzero count for a peak means that region was accessible in that cell.
+
+Two consequences follow immediately, and they drive everything else in the chapter:
+
+1. **The two modalities live in different feature spaces.** One is indexed by genes, the other by genomic coordinates. You cannot simply stack a gene-by-cell matrix on top of a peak-by-cell matrix and call it integrated — the rows mean different things.
+2. **ATAC data is sparse and nearly binary.** Each cell has at most two copies of any locus, so a peak is essentially "seen" or "not seen" in a given cell. The peak matrix is far sparser than the RNA matrix, which changes how we normalize and reduce it (more on this below — it is why ATAC uses TF-IDF and LSI rather than the log-normalization + PCA you used for RNA).
+
+## What "integration" means: vertical, diagonal, mosaic
+
+"Integrate the ATAC with the RNA" can mean several genuinely different problems, and the single most useful thing you can do before reaching for a tool is to figure out *which one you have*. The cleanest way to organize them (after @argelaguet2021computational) is by **what the two datasets share**:
+
+| Shape | What's shared | Typical source | The hard part |
+|---|---|---|---|
+| **Vertical** | the *same cells*, different modalities | 10x **Multiome** (RNA + ATAC per nucleus) | nothing to match — just *combine* the two views well |
+| **Diagonal** | different cells, different modalities | a scRNA run and a *separate* scATAC run | you must **infer** which cells correspond |
+| **Mosaic** | partial overlap | some cells multiome, some single-modality | bridge the measured and the missing |
+
+The distinction is not academic — it changes the method entirely:
+
+- In **vertical** integration the correspondence is *handed to you*. Cell 5's RNA and cell 5's ATAC are the same cell, by construction. The task is to learn a single representation that respects both views — a *joint embedding*. This is the easier, intuition-building case, and where we start.
+- In **diagonal** integration there is no correspondence at all. You have RNA for one set of cells and ATAC for a different set, and nothing tells you that an RNA cell and an ATAC cell are "the same kind." You must *infer* the alignment, almost always by projecting both into a shared feature space (the bridges below) and matching. This is the case that forces you to understand *why* integration is hard, and we return to it in the next chapter using label transfer.
+
+Your collaborators will bring you both. Someone with a 10x Multiome run has a vertical problem. Someone who ran scRNA last year and scATAC this year — same tissue, different cells — has a diagonal one. Same words, "integrate ATAC with RNA," completely different machinery.
+
+## The feature-space problem and the bridges
+
+Because RNA lives in gene space and ATAC in peak space, every integration method needs a **bridge** that puts the two modalities into a common frame. There are three bridges worth knowing, and they are not interchangeable — each answers a different question:
+
+- **Gene-activity scores.** Summarize a gene's accessibility by summing the ATAC signal over its body and promoter (or, better, distance-weighted nearby peaks). This *casts ATAC into gene space*, so an ATAC cell can be compared to an RNA cell gene-for-gene. It is crude — accessibility is not expression — but it is the workhorse bridge for *aligning* unpaired datasets and for *annotating* ATAC cells from an RNA reference.
+- **Peak-to-gene links.** Correlate a peak's accessibility against a gene's expression *across cells*. A peak whose opening tracks a gene's expression is a candidate regulatory element for that gene. This is less a bridge for alignment than a *biological result* — it is how you discover enhancer→gene wiring, and it needs paired (or pseudobulked) data to compute.
+- **Motif / TF activity.** Collapse the tens of thousands of peaks into the handful of transcription factors whose binding motifs they contain (e.g. with `chromVAR`). This turns the unwieldy peak space into a small, interpretable space of TF activities — and TFs are the natural currency for connecting open chromatin back to the genes it regulates.
+
+Keep these three straight and most of the integration literature snaps into focus: methods differ mainly in *which bridge they use* and *whether they need the cells to be paired*.
+
+## The data: 10x PBMC multiome
+
+We'll use a public 10x Genomics dataset of roughly 10,000 peripheral blood mononuclear cells (PBMCs) from a healthy donor, profiled with the Single Cell Multiome assay so that every nucleus has both an RNA and an ATAC measurement. It is a good teaching set: PBMCs contain well-characterized, easily recognized immune cell types (T cells, B cells, monocytes, NK cells), so we have strong priors about what the answer should look like.
+
+Rather than download and reprocess the raw 10x files, we use the curated copy from the Bioconductor `SingleCellMultiModal` package, which delivers the dataset as a `MultiAssayExperiment` — the natural container for "several assays measured on the same cells," and the multi-modal generalization of the `SummarizedExperiment`/`SingleCellExperiment` classes you have already met.
+
+```{r}
+#| label: load-packages
+#| message: false
+library(SingleCellMultiModal)
+library(MultiAssayExperiment)
+library(SingleCellExperiment)
+library(scater)
+library(scran)
+```
+
+A single call fetches the data (the first time, it downloads from Bioconductor's ExperimentHub and caches locally; afterwards it loads from the cache):
+
+```{r}
+#| label: load-data
+mae <- scMultiome("pbmc_10x", modes = "*", dry.run = FALSE, format = "MTX")
+mae
+```
+
+The object bundles two experiments measured on the **same 10,032 cells**:
+
+- `rna` — a `SingleCellExperiment` of gene expression counts (~36,500 genes).
+- `atac` — a `SingleCellExperiment` of peak accessibility counts (~108,000 peaks).
+
+Because they share the same cells, the `MultiAssayExperiment` keeps their column (cell) metadata aligned for us — this is exactly the bookkeeping that makes *vertical* integration tractable. We pull out the two modalities to work with each on its own terms:
+
+```{r}
+#| label: split-modalities
+sce.rna  <- experiments(mae)[["rna"]]
+sce.atac <- experiments(mae)[["atac"]]
+
+sce.rna
+sce.atac
+```
+
+<!--
+================================================================================
+DRAFT BOUNDARY — Commit 1 ends here (conceptual framing + data load, validated API).
+The sections below are the planned analytical arc for Commit 1; the joint-
+integration tooling (MOFA2 vs a lighter pure-R joint embedding) is an open
+decision with dependency/image-rebuild cost — see chapter plan discussion.
+Commit 2 will add the unpaired / diagonal label-transfer section.
+================================================================================
+-->
+
+## Processing each modality on its own terms
+
+::: {.callout-note}
+The per-modality processing below mirrors the RNA workflow from the
+[scRNA-seq chapter](setup.qmd) for the expression side, and introduces
+**TF-IDF + LSI** for the accessibility side — the standard reduction for the
+sparse, near-binary ATAC peak matrix. Code to be finalized against the loaded
+object in the next drafting pass.
+:::
+
+### RNA: log-normalize, select features, reduce
+
+*(Brief — this is the standard scRNA workflow from the previous chapter: library-size normalization, highly variable gene selection, PCA, UMAP. We keep it short and reference back rather than re-teaching it.)*
+
+### ATAC: why log-PCA is wrong here, and what to do instead
+
+*(The conceptual payoff section: the peak matrix is sparse and effectively binary, so the log-normalize-then-PCA recipe from RNA does not apply. Introduce **TF-IDF** (term frequency–inverse document frequency: up-weight peaks that are informative because they are accessible in few cells) followed by **LSI** (latent semantic indexing — an SVD of the TF-IDF matrix). Show the few-line mechanism rather than hiding it in a black-box call, in the spirit of the bulk-ATAC chapter.)*
+
+## A joint embedding: using both views at once
+
+*(The core of the chapter. Build one representation of each cell that draws on RNA and ATAC together, then cluster on it and compare against RNA-only and ATAC-only embeddings — showing where the joint view resolves cell types that either modality alone blurs. Method choice — MOFA2 factors vs. a lighter pure-R concatenated-LSI/PCA embedding vs. illustrating the WNN concept — is the open tooling decision noted above.)*
+
+## Downstream: from open chromatin to regulation
+
+*(Where the biology pays off, and what vertical integration uniquely enables: transcription-factor motif activity with `chromVAR`, and peak-to-gene links that connect a specific open enhancer to the expression of the gene it regulates — in the same cells.)*
+
+## Summary
+
+*(To be written once the analytical sections are final.)*
+
+## What's next: the unpaired case
+
+This chapter handled the *vertical* problem, where the multiome assay handed us the cell correspondence for free. The harder and very common case is *diagonal* integration — a separate scRNA dataset and scATAC dataset with no shared cells — where we must infer the correspondence ourselves. The [next chapter](#) tackles it with **anchor-based label transfer**, and uses a clever trick: we take this very multiome dataset, *throw away* the pairing, and try to recover it — giving us a known ground truth to grade the integration against.

--- a/single_cell/multiome.qmd
+++ b/single_cell/multiome.qmd
@@ -115,10 +115,18 @@ The joint-embedding method we'll use â€” **weighted nearest neighbors (WNN)** â€
 # RNA becomes a standard expression assay.
 pbmc <- CreateSeuratObject(counts = counts(sce.rna), assay = "RNA")
 
-# ATAC becomes a ChromatinAssay. Signac expects peak identifiers shaped like
-# "chr1-9776-10668"; `sep` tells it how the peak rownames are punctuated.
-# (Verify the peak-name format of the loaded object and adjust `sep` if needed.)
-pbmc[["ATAC"]] <- CreateChromatinAssay(counts = counts(sce.atac), sep = c(":", "-"))
+# ATAC becomes a ChromatinAssay, which identifies each peak by its genomic
+# coordinates. Peaks can reach us two ways: as a GRanges in the SCE's rowRanges,
+# or encoded in the rownames as coordinate strings like "chr1:9776-10668". We
+# prefer the GRanges when present and fall back to parsing the rownames.
+atac.counts <- counts(sce.atac)
+peak.ranges <- tryCatch(rowRanges(sce.atac), error = function(e) NULL)
+
+pbmc[["ATAC"]] <- if (is(peak.ranges, "GRanges") && length(peak.ranges) == nrow(atac.counts)) {
+  CreateChromatinAssay(counts = atac.counts, ranges = peak.ranges)
+} else {
+  CreateChromatinAssay(counts = atac.counts, sep = c(":", "-"))
+}
 pbmc
 ```
 
@@ -180,7 +188,7 @@ pbmc <- FindMultiModalNeighbors(
   modality.weight.name = "RNA.weight"
 )
 
-pbmc <- RunUMAP(pbmc, nn.name = "weighted.nn", reduction.name = "wnn.umap")
+pbmc <- RunUMAP(pbmc, nn.name = "weighted.nn", assay = "RNA", reduction.name = "wnn.umap")
 pbmc <- FindClusters(pbmc, graph.name = "wsnn", algorithm = 3, resolution = 0.8)
 ```
 

--- a/single_cell/multiome.qmd
+++ b/single_cell/multiome.qmd
@@ -75,11 +75,11 @@ Rather than download and reprocess the raw 10x files, we use the curated copy fr
 ```{r}
 #| label: load-packages
 #| message: false
-library(SingleCellMultiModal)
-library(MultiAssayExperiment)
-library(SingleCellExperiment)
-library(scater)
-library(scran)
+library(SingleCellMultiModal)   # the curated 10x PBMC multiome dataset
+library(MultiAssayExperiment)   # the multi-modal container
+library(SingleCellExperiment)   # each modality is an SCE
+library(Seurat)                 # WNN joint embedding lives here
+library(Signac)                 # ATAC processing (TF-IDF / LSI) and ChromatinAssay
 ```
 
 A single call fetches the data (the first time, it downloads from Bioconductor's ExperimentHub and caches locally; afterwards it loads from the cache):
@@ -106,45 +106,144 @@ sce.rna
 sce.atac
 ```
 
-<!--
-================================================================================
-DRAFT BOUNDARY — Commit 1 ends here (conceptual framing + data load, validated API).
-The sections below are the planned analytical arc for Commit 1; the joint-
-integration tooling (MOFA2 vs a lighter pure-R joint embedding) is an open
-decision with dependency/image-rebuild cost — see chapter plan discussion.
-Commit 2 will add the unpaired / diagonal label-transfer section.
-================================================================================
--->
+## From Bioconductor to Seurat: building the joint object
 
-## Processing each modality on its own terms
+The joint-embedding method we'll use — **weighted nearest neighbors (WNN)** — lives in the Seurat/Signac ecosystem, which is the de-facto standard for paired multiome. So our first practical step is to bridge our `MultiAssayExperiment` into a Seurat object: the RNA counts become a standard expression assay, and the ATAC peak counts become a Signac **`ChromatinAssay`**. This Bioconductor→Seurat hand-off is worth learning in its own right — you will reach for it constantly, because single-cell data routinely arrives in one ecosystem and the method you want lives in the other.
+
+```{r}
+#| label: to-seurat
+# RNA becomes a standard expression assay.
+pbmc <- CreateSeuratObject(counts = counts(sce.rna), assay = "RNA")
+
+# ATAC becomes a ChromatinAssay. Signac expects peak identifiers shaped like
+# "chr1-9776-10668"; `sep` tells it how the peak rownames are punctuated.
+# (Verify the peak-name format of the loaded object and adjust `sep` if needed.)
+pbmc[["ATAC"]] <- CreateChromatinAssay(counts = counts(sce.atac), sep = c(":", "-"))
+pbmc
+```
 
 ::: {.callout-note}
-The per-modality processing below mirrors the RNA workflow from the
-[scRNA-seq chapter](setup.qmd) for the expression side, and introduces
-**TF-IDF + LSI** for the accessibility side — the standard reduction for the
-sparse, near-binary ATAC peak matrix. Code to be finalized against the loaded
-object in the next drafting pass.
+## We deliberately skip the fragment file
+
+The raw 10x multiome ships a large *fragments* file (every ATAC fragment, genome-wide). The curated dataset gives us the *peak* matrix instead, so we build the `ChromatinAssay` without fragments. WNN needs only the per-modality reductions, so this costs us nothing here — but it does mean genome-browser coverage tracks and fragment-based gene-activity scores aren't available in this chapter. We don't need them for the joint embedding.
 :::
 
-### RNA: log-normalize, select features, reduce
+### RNA reduction: the familiar recipe
 
-*(Brief — this is the standard scRNA workflow from the previous chapter: library-size normalization, highly variable gene selection, PCA, UMAP. We keep it short and reference back rather than re-teaching it.)*
+The expression side is exactly the workflow from the [scRNA-seq chapter](setup.qmd) — normalize, pick highly variable genes, scale, and reduce with PCA:
 
-### ATAC: why log-PCA is wrong here, and what to do instead
+```{r}
+#| label: rna-reduction
+DefaultAssay(pbmc) <- "RNA"
+pbmc <- NormalizeData(pbmc)
+pbmc <- FindVariableFeatures(pbmc, nfeatures = 3000)
+pbmc <- ScaleData(pbmc)
+pbmc <- RunPCA(pbmc, reduction.name = "pca")
+```
 
-*(The conceptual payoff section: the peak matrix is sparse and effectively binary, so the log-normalize-then-PCA recipe from RNA does not apply. Introduce **TF-IDF** (term frequency–inverse document frequency: up-weight peaks that are informative because they are accessible in few cells) followed by **LSI** (latent semantic indexing — an SVD of the TF-IDF matrix). Show the few-line mechanism rather than hiding it in a black-box call, in the spirit of the bulk-ATAC chapter.)*
+### ATAC reduction: why not PCA, and what TF-IDF + LSI do instead
 
-## A joint embedding: using both views at once
+The accessibility side needs a different reduction, and the reason is the structure of the data. Recall that the peak matrix is **sparse and nearly binary**: a cell has at most a couple of copies of any locus, so most entries are 0 and the rest are small. Log-normalization-then-PCA, which works well for the graded counts of RNA, is a poor fit for this on/off signal.
 
-*(The core of the chapter. Build one representation of each cell that draws on RNA and ATAC together, then cluster on it and compare against RNA-only and ATAC-only embeddings — showing where the joint view resolves cell types that either modality alone blurs. Method choice — MOFA2 factors vs. a lighter pure-R concatenated-LSI/PCA embedding vs. illustrating the WNN concept — is the open tooling decision noted above.)*
+The standard reduction for ATAC is **TF-IDF followed by LSI**:
 
-## Downstream: from open chromatin to regulation
+- **TF-IDF** (term frequency–inverse document frequency, borrowed from text analysis, where "documents" are cells and "terms" are peaks) up-weights peaks that are informative *because* they are accessible in only a few cells, and down-weights peaks open everywhere. It is how we let rare, cell-type-defining peaks carry more signal than ubiquitous ones.
+- **LSI** (latent semantic indexing) is then just a singular value decomposition of the TF-IDF matrix — the accessibility analogue of PCA.
 
-*(Where the biology pays off, and what vertical integration uniquely enables: transcription-factor motif activity with `chromVAR`, and peak-to-gene links that connect a specific open enhancer to the expression of the gene it regulates — in the same cells.)*
+```{r}
+#| label: atac-reduction
+DefaultAssay(pbmc) <- "ATAC"
+pbmc <- FindTopFeatures(pbmc, min.cutoff = 5)   # keep peaks seen in >= 5 cells
+pbmc <- RunTFIDF(pbmc)                           # normalize
+pbmc <- RunSVD(pbmc, reduction.name = "lsi")     # the SVD that makes it "LSI"
+```
+
+There is one wrinkle worth teaching because it trips people up: the **first LSI component usually captures sequencing depth, not biology** — cells with more total fragments score high on it regardless of type. We check this and, if so, exclude component 1 from everything downstream (using dimensions `2:n` instead of `1:n`):
+
+```{r}
+#| label: lsi-depthcor
+DepthCor(pbmc, reduction = "lsi")
+```
+
+## A joint embedding with weighted nearest neighbors
+
+Here is the heart of vertical integration. We have two reductions of the same cells — a PCA from RNA and an LSI from ATAC — and we want **one** representation that uses both. The naive approach (just glue the two sets of components together) treats every cell as trusting both modalities equally. But that is rarely true: for some cells the RNA cleanly says "T cell" while the ATAC is murky, and for others the reverse.
+
+**WNN** handles exactly this. For *each individual cell* it learns a pair of weights — how much to trust RNA versus ATAC — by asking which modality better predicts that cell's near neighbors. It then builds a single neighbor graph from the weighted combination. The output is a joint graph we can embed (UMAP) and cluster, where each cell's contribution from each modality is tuned to that cell.
+
+```{r}
+#| label: wnn
+pbmc <- FindMultiModalNeighbors(
+  pbmc,
+  reduction.list = list("pca", "lsi"),
+  dims.list = list(1:50, 2:40),        # RNA PCA 1:50; ATAC LSI drops component 1
+  modality.weight.name = "RNA.weight"
+)
+
+pbmc <- RunUMAP(pbmc, nn.name = "weighted.nn", reduction.name = "wnn.umap")
+pbmc <- FindClusters(pbmc, graph.name = "wsnn", algorithm = 3, resolution = 0.8)
+```
+
+### What did the joint view buy us?
+
+The payoff is clearest when we put all three embeddings side by side — RNA alone, ATAC alone, and the WNN joint view — and look for cell populations that one modality blurs but the other (and so the joint view) resolves:
+
+```{r}
+#| label: single-modality-umaps
+pbmc <- RunUMAP(pbmc, reduction = "pca", dims = 1:50, reduction.name = "rna.umap")
+pbmc <- RunUMAP(pbmc, reduction = "lsi", dims = 2:40, reduction.name = "atac.umap")
+```
+
+```{r}
+#| label: compare-umaps
+#| fig-width: 12
+#| fig-height: 4
+p1 <- DimPlot(pbmc, reduction = "rna.umap")  + ggtitle("RNA only")
+p2 <- DimPlot(pbmc, reduction = "atac.umap") + ggtitle("ATAC only")
+p3 <- DimPlot(pbmc, reduction = "wnn.umap")  + ggtitle("WNN (joint)")
+p1 + p2 + p3
+```
+
+We can also look directly at what WNN learned — the per-cell modality weights. Plotting the RNA weight by cluster shows *which cell types lean on expression and which lean on accessibility* to define themselves:
+
+```{r}
+#| label: modality-weights
+VlnPlot(pbmc, features = "RNA.weight", group.by = "seurat_clusters", pt.size = 0)
+```
+
+## Downstream: linking a peak to the gene it regulates
+
+The unique payoff of *paired* data is that we can connect a specific open region to a specific gene's expression **in the same cells**. The honest, transparent way to see the idea is to compute it by hand for one locus: take a cell-type marker gene, find the accessible peaks near it, and ask whether a peak's accessibility *tracks* the gene's expression across cells. A peak that does is a candidate regulatory element for that gene.
+
+We'll use `MS4A1` (CD20), a canonical B-cell marker. We need its genomic location, which we pull from an Ensembl annotation:
+
+```{r}
+#| label: peak-gene-link
+#| eval: false
+library(EnsDb.Hsapiens.v86)
+
+# 1. Locate MS4A1 and define a +/- 100 kb window around it.
+# 2. Find ATAC peaks overlapping that window (peaks already carry coordinates).
+# 3. Spearman-correlate each peak's accessibility against MS4A1 expression
+#    across all cells; the highest-correlating peaks are candidate enhancers.
+#
+# This hand-rolled correlation is the transparent core of what Signac's
+# LinkPeaks() does with added GC/background correction — which needs a BSgenome
+# and the fragment file we deliberately skipped. Code finalized on first render.
+```
+
+::: {.callout-tip}
+## Where this goes next
+Production tools formalize this step: `Signac::LinkPeaks()` adds GC-content and background correction (at the cost of a `BSgenome` and the fragment file), and full gene-regulatory-network methods (SCENIC+, Pando) chain peak→gene links with transcription-factor motifs to reconstruct regulatory circuits. We compute the bare correlation here so the *concept* is unmistakable.
+:::
 
 ## Summary
 
-*(To be written once the analytical sections are final.)*
+- **RNA and ATAC are complementary**: expression is the output, accessibility is the regulatory wiring — and a cell can open a locus before it transcribes the gene.
+- **Know your integration shape first.** This was a **vertical** problem: a multiome assay handed us the cell correspondence, so the task was to *combine* two views, not to *match* cells.
+- **The two modalities live in different feature spaces** (genes vs. peaks), and the sparse, near-binary ATAC matrix needs **TF-IDF + LSI**, not the log-PCA recipe used for RNA — and its first LSI component usually encodes depth, not biology.
+- **WNN** builds a single embedding by learning, per cell, how much to trust each modality — recovering structure that either modality alone can blur.
+- **Paired data uniquely lets you link peaks to genes** in the same cells, the first step toward reconstructing regulatory logic.
 
 ## What's next: the unpaired case
 

--- a/single_cell/multiome.qmd
+++ b/single_cell/multiome.qmd
@@ -80,6 +80,8 @@ library(MultiAssayExperiment)   # the multi-modal container
 library(SingleCellExperiment)   # each modality is an SCE
 library(Seurat)                 # WNN joint embedding lives here
 library(Signac)                 # ATAC processing (TF-IDF / LSI) and ChromatinAssay
+library(ggplot2)                # ggtitle() to label the comparison panels
+library(patchwork)              # compose plots side by side with `+`
 ```
 
 A single call fetches the data (the first time, it downloads from Bioconductor's ExperimentHub and caches locally; afterwards it loads from the cache):

--- a/single_cell/multiome.qmd
+++ b/single_cell/multiome.qmd
@@ -253,22 +253,46 @@ VlnPlot(pbmc, features = "RNA.weight", group.by = "seurat_clusters", pt.size = 0
 
 The unique payoff of *paired* data is that we can connect a specific open region to a specific gene's expression **in the same cells**. The honest, transparent way to see the idea is to compute it by hand for one locus: take a cell-type marker gene, find the accessible peaks near it, and ask whether a peak's accessibility *tracks* the gene's expression across cells. A peak that does is a candidate regulatory element for that gene.
 
-We'll use `MS4A1` (CD20), a canonical B-cell marker. We need its genomic location, which we pull from an Ensembl annotation:
+We'll use `MS4A1` (CD20), a canonical B-cell marker. The logic is three steps: find the gene, find the peaks near it, then correlate.
+
+**Step 1 — locate the gene.** We pull MS4A1's coordinates from an Ensembl annotation and relabel its chromosome in the `chr11` (UCSC) style the ATAC peaks use, then widen to a ±100 kb window — wide enough to catch enhancers, which often sit well outside the gene body:
 
 ```{r}
-#| label: peak-gene-link
-#| eval: false
+#| label: peak-gene-locate
+#| message: false
 library(EnsDb.Hsapiens.v86)
 
-# 1. Locate MS4A1 and define a +/- 100 kb window around it.
-# 2. Find ATAC peaks overlapping that window (peaks already carry coordinates).
-# 3. Spearman-correlate each peak's accessibility against MS4A1 expression
-#    across all cells; the highest-correlating peaks are candidate enhancers.
-#
-# This hand-rolled correlation is the transparent core of what Signac's
-# LinkPeaks() does with added GC/background correction — which needs a BSgenome
-# and the fragment file we deliberately skipped. Code finalized on first render.
+gene <- "MS4A1"
+all.genes <- genes(EnsDb.Hsapiens.v86)              # every gene, as a GRanges
+gene.gr   <- all.genes[all.genes$gene_name == gene] # subset to MS4A1
+seqlevelsStyle(gene.gr) <- "UCSC"                   # "11" -> "chr11"
+window <- resize(gene.gr, width = width(gene.gr) + 2e5, fix = "center")
+window
 ```
+
+**Step 2 — find nearby peaks.** The `ChromatinAssay` carries each peak's coordinates, so we ask which peaks fall inside the window. We index back into the assay's own peak names so the identifiers match exactly:
+
+```{r}
+#| label: peak-gene-overlap
+peak.gr  <- granges(pbmc[["ATAC"]])
+idx      <- queryHits(findOverlaps(peak.gr, window))
+peak.ids <- rownames(pbmc[["ATAC"]])[idx]
+length(peak.ids)                                    # how many peaks sit near MS4A1?
+```
+
+**Step 3 — correlate accessibility with expression.** For each nearby peak we compute the Spearman correlation, across all 10,032 cells, between that peak's accessibility and MS4A1's expression. A peak whose opening rises and falls *with* the gene's expression is a candidate regulatory element for it:
+
+```{r}
+#| label: peak-gene-correlate
+#| warning: false
+acc  <- GetAssayData(pbmc, assay = "ATAC", slot = "data")[peak.ids, , drop = FALSE]
+expr <- GetAssayData(pbmc, assay = "RNA",  slot = "data")[gene, ]
+
+peak.cor <- apply(acc, 1, function(a) cor(a, expr, method = "spearman"))
+sort(peak.cor, decreasing = TRUE)[1:10]             # the top candidate links
+```
+
+The most strongly correlated peak is typically the gene's own promoter; the others are candidate enhancers that open in the same cells that express MS4A1 — precisely the sort of regulatory link that only *paired* measurement, in the same cells, can reveal.
 
 ::: {.callout-tip}
 ## Where this goes next

--- a/single_cell/multiome.qmd
+++ b/single_cell/multiome.qmd
@@ -285,8 +285,8 @@ length(peak.ids)                                    # how many peaks sit near MS
 ```{r}
 #| label: peak-gene-correlate
 #| warning: false
-acc  <- GetAssayData(pbmc, assay = "ATAC", slot = "data")[peak.ids, , drop = FALSE]
-expr <- GetAssayData(pbmc, assay = "RNA",  slot = "data")[gene, ]
+acc  <- GetAssayData(pbmc, assay = "ATAC", layer = "data")[peak.ids, , drop = FALSE]
+expr <- GetAssayData(pbmc, assay = "RNA",  layer = "data")[gene, ]
 
 peak.cor <- apply(acc, 1, function(a) cor(a, expr, method = "spearman"))
 sort(peak.cor, decreasing = TRUE)[1:10]             # the top candidate links

--- a/single_cell/multiome.qmd
+++ b/single_cell/multiome.qmd
@@ -14,7 +14,7 @@ Why does the wiring matter if you can already see the output? Because a cell oft
 
 The technology that makes this concrete is the **multiome** assay (here, 10x Genomics' Single Cell Multiome ATAC + Gene Expression), which measures *both* RNA and open chromatin in the *same nucleus*. That "same nucleus" is the crucial part. With separate experiments you can only compare populations — the average RNA of one batch of cells against the average accessibility of another. With a multiome you can ask a cause-and-effect question inside a single cell: *this* enhancer is open, and *this* gene, which it controls, is expressed, in this very cell. That is what lets you move from cataloguing cell types to reconstructing the regulatory logic that defines them.
 
-This chapter is about **integration**: combining the two modalities into one coherent analysis instead of two parallel ones. We will build the intuition for what integration means, why it is harder than it sounds, and then do it hands-on with a public 10x PBMC multiome dataset that ships ready-to-use as a Bioconductor `MultiAssayExperiment`.
+This chapter is about **integration**: combining the two modalities into one coherent analysis instead of two parallel ones. We will build the intuition for what integration means, why it is harder than it sounds, and then do it hands-on with a public 10x PBMC multiome dataset that ships ready-to-use as a Bioconductor `MultiAssayExperiment`. For the wider landscape of single-cell multi-omic technologies and the computational methods that pair with them, two reviews are good companions to this chapter [@argelaguet2021computational; @vandereyken2023methods].
 
 ## What you'll learn
 
@@ -62,7 +62,7 @@ Because RNA lives in gene space and ATAC in peak space, every integration method
 
 - **Gene-activity scores.** Summarize a gene's accessibility by summing the ATAC signal over its body and promoter (or, better, distance-weighted nearby peaks). This *casts ATAC into gene space*, so an ATAC cell can be compared to an RNA cell gene-for-gene. It is crude — accessibility is not expression — but it is the workhorse bridge for *aligning* unpaired datasets and for *annotating* ATAC cells from an RNA reference.
 - **Peak-to-gene links.** Correlate a peak's accessibility against a gene's expression *across cells*. A peak whose opening tracks a gene's expression is a candidate regulatory element for that gene. This is less a bridge for alignment than a *biological result* — it is how you discover enhancer→gene wiring, and it needs paired (or pseudobulked) data to compute.
-- **Motif / TF activity.** Collapse the tens of thousands of peaks into the handful of transcription factors whose binding motifs they contain (e.g. with `chromVAR`). This turns the unwieldy peak space into a small, interpretable space of TF activities — and TFs are the natural currency for connecting open chromatin back to the genes it regulates.
+- **Motif / TF activity.** Collapse the tens of thousands of peaks into the handful of transcription factors whose binding motifs they contain (e.g. with `chromVAR` [@schep2017chromvar]). This turns the unwieldy peak space into a small, interpretable space of TF activities — and TFs are the natural currency for connecting open chromatin back to the genes it regulates.
 
 Keep these three straight and most of the integration literature snaps into focus: methods differ mainly in *which bridge they use* and *whether they need the cells to be paired*.
 
@@ -70,7 +70,7 @@ Keep these three straight and most of the integration literature snaps into focu
 
 We'll use a public 10x Genomics dataset of roughly 10,000 peripheral blood mononuclear cells (PBMCs) from a healthy donor, profiled with the Single Cell Multiome assay so that every nucleus has both an RNA and an ATAC measurement. It is a good teaching set: PBMCs contain well-characterized, easily recognized immune cell types (T cells, B cells, monocytes, NK cells), so we have strong priors about what the answer should look like.
 
-Rather than download and reprocess the raw 10x files, we use the curated copy from the Bioconductor `SingleCellMultiModal` package, which delivers the dataset as a `MultiAssayExperiment` — the natural container for "several assays measured on the same cells," and the multi-modal generalization of the `SummarizedExperiment`/`SingleCellExperiment` classes you have already met.
+Rather than download and reprocess the raw 10x files, we use the curated copy from the Bioconductor `SingleCellMultiModal` package [@eckenrode2023curated], which delivers the dataset as a `MultiAssayExperiment` — the natural container for "several assays measured on the same cells," and the multi-modal generalization of the `SummarizedExperiment`/`SingleCellExperiment` classes you have already met.
 
 ```{r}
 #| label: load-packages
@@ -110,7 +110,7 @@ sce.atac
 
 ## From Bioconductor to Seurat: building the joint object
 
-The joint-embedding method we'll use — **weighted nearest neighbors (WNN)** — lives in the Seurat/Signac ecosystem, which is the de-facto standard for paired multiome. So our first practical step is to bridge our `MultiAssayExperiment` into a Seurat object: the RNA counts become a standard expression assay, and the ATAC peak counts become a Signac **`ChromatinAssay`**. This Bioconductor→Seurat hand-off is worth learning in its own right — you will reach for it constantly, because single-cell data routinely arrives in one ecosystem and the method you want lives in the other.
+The joint-embedding method we'll use — **weighted nearest neighbors (WNN)** — lives in the Seurat/Signac ecosystem [@stuart2021signac], which is the de-facto standard for paired multiome. So our first practical step is to bridge our `MultiAssayExperiment` into a Seurat object: the RNA counts become a standard expression assay, and the ATAC peak counts become a Signac **`ChromatinAssay`**. This Bioconductor→Seurat hand-off is worth learning in its own right — you will reach for it constantly, because single-cell data routinely arrives in one ecosystem and the method you want lives in the other.
 
 ```{r}
 #| label: to-seurat
@@ -153,25 +153,49 @@ pbmc <- RunPCA(pbmc, reduction.name = "pca")
 
 ### ATAC reduction: why not PCA, and what TF-IDF + LSI do instead
 
-The accessibility side needs a different reduction, and the reason is the structure of the data. Recall that the peak matrix is **sparse and nearly binary**: a cell has at most a couple of copies of any locus, so most entries are 0 and the rest are small. Log-normalization-then-PCA, which works well for the graded counts of RNA, is a poor fit for this on/off signal.
+The accessibility side needs a different reduction, and the reason is the structure of the data. Recall that the peak matrix is **sparse and nearly binary**: a cell has at most a couple of copies of any locus, so most entries are 0 and the rest are small. Log-normalization-then-PCA, which works well for the graded counts of RNA, is a poor fit for this on/off signal. The fix, worked out for the earliest single-cell ATAC experiments [@cusanovich2015multiplex], borrows two ideas from how search engines compare text documents: **TF-IDF**, then **LSI**.
 
-The standard reduction for ATAC is **TF-IDF followed by LSI**:
+#### TF-IDF, in miniature
 
-- **TF-IDF** (term frequency–inverse document frequency, borrowed from text analysis, where "documents" are cells and "terms" are peaks) up-weights peaks that are informative *because* they are accessible in only a few cells, and down-weights peaks open everywhere. It is how we let rare, cell-type-defining peaks carry more signal than ubiquitous ones.
-- **LSI** (latent semantic indexing) is then just a singular value decomposition of the TF-IDF matrix — the accessibility analogue of PCA.
+**TF-IDF** stands for *term frequency–inverse document frequency*. The analogy is to text: if cells are "documents" and peaks are "words," then a peak open in nearly every cell is like the word *the* — common, and therefore almost useless for telling documents apart — while a peak open in just a handful of cells is like a rare, distinctive word that pins down which documents resemble each other. TF-IDF rewrites each entry so that rare, informative peaks count for more and ubiquitous ones count for less.
+
+The quickest way to *feel* this is to do it by hand on a tiny matrix — four cells, three peaks, `1` meaning "accessible":
+
+```{r}
+#| label: tfidf-toy
+# rows = peaks, columns = cells; 1 = accessible in that cell
+toy <- matrix(c(1, 1, 1, 1,    # peak A: open everywhere (an uninformative "the")
+                1, 1, 0, 0,    # peak B: open in half the cells
+                0, 0, 0, 1),   # peak C: open in one cell (rare, distinctive)
+              nrow = 3, byrow = TRUE,
+              dimnames = list(c("peakA", "peakB", "peakC"),
+                              c("c1", "c2", "c3", "c4")))
+
+n_cells   <- ncol(toy)
+peak_freq <- rowSums(toy)                  # in how many cells is each peak open?
+idf       <- log(1 + n_cells / peak_freq)  # inverse document frequency = the weight
+round(idf, 2)
+```
+
+The ubiquitous peak A gets the smallest weight and the rare peak C the largest — precisely the re-weighting we want before we go looking for structure. (Signac's `RunTFIDF()` uses a refined version of this same idea; the toy captures the intuition, not the exact formula.)
+
+#### LSI: a PCA for the re-weighted matrix
+
+Once the peak matrix is re-weighted, **LSI** (*latent semantic indexing*) reduces it to a handful of components using a **singular value decomposition (SVD)** — mathematically the same machinery as PCA, applied to the TF-IDF matrix instead of a scaled expression matrix. Each component is a *latent* pattern of co-accessible peaks: a set of regulatory regions that tend to open together across cells. Where PCA on RNA finds axes of co-expressed genes, LSI on ATAC finds axes of co-accessible peaks — and those axes are what separate one cell state from another.
 
 ```{r}
 #| label: atac-reduction
 DefaultAssay(pbmc) <- "ATAC"
 pbmc <- FindTopFeatures(pbmc, min.cutoff = 5)   # keep peaks seen in >= 5 cells
-pbmc <- RunTFIDF(pbmc)                           # normalize
+pbmc <- RunTFIDF(pbmc)                           # re-weight (TF-IDF)
 pbmc <- RunSVD(pbmc, reduction.name = "lsi")     # the SVD that makes it "LSI"
 ```
 
-There is one wrinkle worth teaching because it trips people up: the **first LSI component usually captures sequencing depth, not biology** — cells with more total fragments score high on it regardless of type. We check this and, if so, exclude component 1 from everything downstream (using dimensions `2:n` instead of `1:n`):
+There is one wrinkle worth teaching because it trips people up: the **first LSI component usually captures sequencing depth, not biology**. The reason is mechanical — a cell sequenced more deeply has more fragments and therefore more nonzero peaks across the board, so the single largest axis of variation in the data is often just "how much was this cell sequenced," not "what kind of cell is it." We check for this with `DepthCor()`, which correlates each component against each cell's total counts, and routinely drop component 1 (using dimensions `2:n` instead of `1:n`):
 
 ```{r}
 #| label: lsi-depthcor
+#| fig-cap: "Correlation between each LSI component and the total ATAC fragment count per cell. The first component is almost perfectly correlated with sequencing depth — a technical artifact, not biology — which is why we exclude it from every downstream step and use components 2 onward. The later components show little correlation with depth and are the ones carrying the cell-type signal."
 DepthCor(pbmc, reduction = "lsi")
 ```
 
@@ -179,7 +203,9 @@ DepthCor(pbmc, reduction = "lsi")
 
 Here is the heart of vertical integration. We have two reductions of the same cells — a PCA from RNA and an LSI from ATAC — and we want **one** representation that uses both. The naive approach (just glue the two sets of components together) treats every cell as trusting both modalities equally. But that is rarely true: for some cells the RNA cleanly says "T cell" while the ATAC is murky, and for others the reverse.
 
-**WNN** handles exactly this. For *each individual cell* it learns a pair of weights — how much to trust RNA versus ATAC — by asking which modality better predicts that cell's near neighbors. It then builds a single neighbor graph from the weighted combination. The output is a joint graph we can embed (UMAP) and cluster, where each cell's contribution from each modality is tuned to that cell.
+**Weighted nearest neighbors (WNN)** [@hao2021integrated] handles exactly this by letting *every cell weight the two modalities for itself*. The intuition is a panel of two advisors. Suppose you must sort people into groups by similarity, and you have two advisors: one judges by what people *say* (RNA), the other by what they are *poised to do* (ATAC). For some people the first advisor is far more reliable; for others, the second. The sensible strategy is to ask, *for each person individually*, which advisor's notion of "similar people" better matches that person — and to trust that advisor more for that person.
+
+That is essentially WNN's algorithm. For each cell it asks: using this cell's RNA neighbors, how well can I reconstruct the cell's own RNA profile — and using its ATAC neighbors, how well can I reconstruct its own ATAC profile? Whichever modality predicts the cell better earns a higher weight *for that cell*. These per-cell weights (a number between 0 and 1 for each modality, the two summing to 1) then merge the two neighbor graphs into a single **weighted nearest-neighbor graph**, which we embed with UMAP and cluster exactly as we would a single-modality graph.
 
 ```{r}
 #| label: wnn
@@ -208,16 +234,18 @@ pbmc <- RunUMAP(pbmc, reduction = "lsi", dims = 2:40, reduction.name = "atac.uma
 #| label: compare-umaps
 #| fig-width: 12
 #| fig-height: 4
+#| fig-cap: "The same PBMCs embedded three ways; every point is a cell, colored by its WNN joint cluster. **Left (RNA only):** UMAP from gene expression alone. **Middle (ATAC only):** UMAP from chromatin accessibility alone — typically blurrier, because the near-binary ATAC signal carries less information per cell than expression does. **Right (WNN, joint):** the embedding that weights both modalities per cell. Read the figure by following one color across the three panels: a cluster that is smeared or split in a single-modality panel but compact and cleanly separated in the joint panel is a population the joint view resolves better than either modality alone. Because the points are colored by the *joint* clusters, the right-hand panel is the one in which they should look tightest and best separated."
 p1 <- DimPlot(pbmc, reduction = "rna.umap")  + ggtitle("RNA only")
 p2 <- DimPlot(pbmc, reduction = "atac.umap") + ggtitle("ATAC only")
 p3 <- DimPlot(pbmc, reduction = "wnn.umap")  + ggtitle("WNN (joint)")
 p1 + p2 + p3
 ```
 
-We can also look directly at what WNN learned — the per-cell modality weights. Plotting the RNA weight by cluster shows *which cell types lean on expression and which lean on accessibility* to define themselves:
+We can also look directly at what WNN learned — the per-cell modality weights. Each cell received an RNA weight (and an ATAC weight equal to 1 − the RNA weight); plotting the RNA weight by cluster shows *which cell types lean on expression and which lean on accessibility* to define themselves:
 
 ```{r}
 #| label: modality-weights
+#| fig-cap: "Per-cell RNA modality weight, grouped by WNN cluster. A value near 1 means WNN found that cell's identity better defined by gene expression; a low value means chromatin accessibility was the more informative modality for that cell. Clusters sitting well above 0.5 are 'RNA-driven'; those below are 'ATAC-driven.' The differences between clusters are the biological readout — they tell you which populations are distinguished more by what they transcribe versus how their chromatin is configured."
 VlnPlot(pbmc, features = "RNA.weight", group.by = "seurat_clusters", pt.size = 0)
 ```
 


### PR DESCRIPTION
## Chapter: Integrating single-cell ATAC and RNA (paired / multiome)

Adds `single_cell/multiome.qmd` — vertical (paired) integration on the 10x PBMC
multiome dataset, plus the CI/infra changes that support it. Split out from the
combined integration work so it can land independently; the companion **unpaired
label-transfer** chapter follows in a separate PR.

### Contents
- Lecture-ready framing (RNA-as-output / ATAC-as-wiring; vertical/diagonal/mosaic;
  feature-space mismatch and the gene-activity / peak-gene / motif bridges).
- Data loaded as a `MultiAssayExperiment` via `SingleCellMultiModal::scMultiome("pbmc_10x")`.
- Bioconductor→Seurat/Signac bridge → RNA PCA + ATAC TF-IDF/LSI (with a runnable
  TF-IDF toy) → **WNN** joint embedding (RNA/ATAC/joint comparison + modality weights)
  → a light, hand-rolled peak↔gene correlation.
- Full figure legends; references incl. reviews.

### Infra (needed by this chapter)
- `DESCRIPTION`: add `Seurat`, `Signac`, `SingleCellMultiModal`, `SingleCellExperiment`,
  `MultiAssayExperiment`, `EnsDb.Hsapiens.v86`.
- `Dockerfile`: retry transient dependency downloads and **fail the build** if any
  declared package is missing (fixes the silent-failure that dropped `modeltools`).

This chapter already rendered green (all formats) prior to the split. The "What's next"
link is a placeholder until the label-transfer PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
