### PR TITLE
ci: auto-commit regenerated _freeze back to main

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -66,6 +66,35 @@ jobs:
           target: gh-pages
           render: false
 
+      - name: Commit regenerated _freeze back to main
+        # `execute: freeze: auto` reuses committed _freeze/ and only re-executes a
+        # chapter when its source changed. This step persists whatever quarto just
+        # regenerated, so the NEXT render reuses it instead of re-executing the
+        # (slow) chapters from scratch — keeping CI and publishes fast and the
+        # executed results deterministic and version-controlled.
+        #
+        # Push-to-main only. No infinite loop: pushes made with GITHUB_TOKEN do not
+        # trigger new workflow runs, and the bot commit is tagged [skip ci] as a
+        # belt-and-suspenders guard. A no-op when nothing re-executed (the common
+        # case). The job already grants contents: write.
+        if: github.event_name == 'push'
+        run: |
+          if [ -z "$(git status --porcelain -- _freeze)" ]; then
+            echo "No _freeze changes to commit."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add _freeze
+          git commit -m "chore(freeze): cache regenerated execution results [skip ci]"
+          # Fast-forward in the common case; if main advanced mid-render, merge
+          # (never rebase) and retry. cancel-in-progress usually preempts this race.
+          git push origin "HEAD:${GITHUB_REF_NAME}" || {
+            git fetch origin "${GITHUB_REF_NAME}"
+            git merge --no-edit "origin/${GITHUB_REF_NAME}"
+            git push origin "HEAD:${GITHUB_REF_NAME}"
+          }
+
   # Fast HTML-only Netlify deploy preview for PRs. Runs alongside (not instead of)
   # the full R-CMD-check job, so pdf/epub breakage is still caught on the PR.
   preview-render:


### PR DESCRIPTION
## ci: auto-commit regenerated `_freeze/` back to `main`

Makes the book's committed-`_freeze` model self-maintaining. On **push to `main`**, after the render+publish, the `R-CMD-check` job commits whatever `quarto render` just regenerated under `_freeze/` back to `main`. The next render then reuses those frozen results instead of re-executing chapters from scratch.

### Why
`execute: freeze: auto` reuses committed `_freeze/` and only re-executes a chapter when its source changes. But nothing was committing the freshly-executed results, so chapters without committed freeze (currently `single_cell/multiome` and `single_cell/atac_rna_label_transfer`) get **re-executed on every render** (~40 min). After this lands, the first `main` render executes them once, commits the freeze, and every subsequent render is fast — and the executed results become deterministic and version-controlled. No more hand-rendering heavy chapters.

### Safety
- **No infinite loop (two guards):** pushes made with `GITHUB_TOKEN` do **not** trigger new workflow runs (GitHub built-in), *and* the bot commit is tagged `[skip ci]`.
- **`main` only** (`if: github.event_name == 'push'`); never on PRs.
- **No-op when nothing re-executed** — the common case (skips cleanly if `_freeze/` is unchanged).
- **Race-safe:** fast-forward in the common case; if `main` advanced mid-render, it merges (never rebases) and retries. `cancel-in-progress` usually preempts the race anyway.
- Uses the job's existing `contents: write`; no new secrets.

### One thing to check before/after merge
If `main` has **branch protection that restricts who can push**, the `GITHUB_TOKEN` push may be rejected — in that case allow `github-actions[bot]` to bypass, or swap in a PAT/app token. If pushes by Actions are currently allowed, nothing to do.

### After merge
The next push to `main` will execute `multiome` + `atac_rna_label_transfer` once and commit their `_freeze/` (all three formats), retroactively fixing the slow-render situation for both chapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
