### PR TITLE
ci: drop render --debug, bump deprecated Node-20 actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,7 +58,7 @@ jobs:
       OMP_NUM_THREADS: "1"
       OPENBLAS_NUM_THREADS: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -85,7 +85,7 @@ jobs:
         run: |
           export R_DEFAULT_INTERNET_TIMEOUT=120
           set -o pipefail
-          timeout --signal=INT --kill-after=60 1800 quarto render --debug 2>&1 | tee /tmp/render.log
+          timeout --signal=INT --kill-after=60 1800 quarto render 2>&1 | tee /tmp/render.log
           rc=$?
           if [ "$rc" -ne 0 ]; then
             echo "::group::render.log tail (exit $rc; 124 = step timeout)"
@@ -149,7 +149,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -170,7 +170,7 @@ jobs:
         run: |
           printf '/*\n  X-Robots-Tag: noindex\n' > _book/_headers
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: book-html
           path: _book
@@ -185,13 +185,13 @@ jobs:
       contents: read
       pull-requests: write # post the preview URL as a PR comment
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: book-html
           path: _book
 
       - name: Deploy preview to Netlify
-        uses: nwtgck/actions-netlify@v3
+        uses: nwtgck/actions-netlify@v4
         with:
           publish-dir: _book
           production-deploy: false

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -20,17 +20,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
Follow-up housekeeping after the mermaid→Chrome CI-hang fix (#49).

## Changes
- **Drop `--debug`** from the `quarto render` step. It was added to trace the hang; now that the hang is fixed it just bloats CI logs. The `timeout` backstop and on-failure log-tail dump stay (they made the hang diagnosable), and the step comment already documents `--debug` as an opt-in for future stalls.
- **Bump Node-20-deprecated actions** to current Node-24 majors:

  | Action | Was | Now |
  |--------|-----|-----|
  | actions/checkout | v4 | v6 |
  | actions/upload-artifact | v4 | v7 |
  | actions/download-artifact | v4 | v8 |
  | nwtgck/actions-netlify | v3 | v4 |
  | docker/setup-buildx-action | v3 | v4 |
  | docker/login-action | v3 | v4 |
  | docker/build-push-action | v6 | v7 |

## Notes
- `upload-artifact@v7` / `download-artifact@v8` both use the post-v4 artifact backend, so they interoperate.
- `quarto-dev/quarto-actions/publish` stays at its current `v2` major (never Node-20-flagged).
- The `build-image.yml` bumps aren't exercised by this PR's checks; they validate on the next image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)